### PR TITLE
Show vaults

### DIFF
--- a/src/components/CollateralChoice.tsx
+++ b/src/components/CollateralChoice.tsx
@@ -7,7 +7,7 @@ import type { Amount } from '@agoric/ertp/src/types';
 const CollateralChoice = ({ id }: { id: string }) => {
   const {
     vaultGovernedParams,
-    vaultLoadingErrors,
+    vaultManagerLoadingErrors,
     vaultManagers,
     vaultMetrics,
     prices,
@@ -24,7 +24,7 @@ const CollateralChoice = ({ id }: { id: string }) => {
   const price = brand && prices.get(brand);
 
   const error =
-    vaultLoadingErrors.get(id) ||
+    vaultManagerLoadingErrors.get(id) ||
     (brand && priceErrors.get(brand)) ||
     vaultFactoryParamsLoadingError;
   const displayFunctions = useAtomValue(displayFunctionsAtom);

--- a/src/components/ManageVaults.tsx
+++ b/src/components/ManageVaults.tsx
@@ -1,0 +1,23 @@
+import { useVaultStore } from 'store/vaults';
+import VaultSummary from 'components/VaultSummary';
+import { useAtomValue } from 'jotai';
+import { displayFunctionsAtom } from 'store/app';
+
+const ManageVaults = () => {
+  const vaults = useVaultStore(state => state.vaults);
+  const displayFunctions = useAtomValue(displayFunctionsAtom);
+  const content = displayFunctions ? (
+    [...vaults.entries()].map(([key]) => <VaultSummary id={key} key={key} />)
+  ) : (
+    <p>Loading...</p>
+  );
+
+  return (
+    <>
+      <h2>Manage vaults:</h2>
+      <div className="flex gap-4 flex-wrap p-1">{content}</div>
+    </>
+  );
+};
+
+export default ManageVaults;

--- a/src/components/ManageVaults.tsx
+++ b/src/components/ManageVaults.tsx
@@ -7,7 +7,9 @@ const ManageVaults = () => {
   const vaults = useVaultStore(state => state.vaults);
   const displayFunctions = useAtomValue(displayFunctionsAtom);
   const content = displayFunctions ? (
-    [...vaults.entries()].map(([key]) => <VaultSummary id={key} key={key} />)
+    [...vaults.entries()].map(([key]) => (
+      <VaultSummary key={key} vaultKey={key} />
+    ))
   ) : (
     <p>Loading...</p>
   );

--- a/src/components/NewVault.tsx
+++ b/src/components/NewVault.tsx
@@ -8,7 +8,7 @@ type Props = { id: string };
 const NewVault = ({ id }: Props) => {
   const {
     vaultGovernedParams,
-    vaultLoadingErrors,
+    vaultManagerLoadingErrors,
     vaultManagers,
     vaultMetrics,
     prices,
@@ -22,7 +22,7 @@ const NewVault = ({ id }: Props) => {
   const price = brand && prices.get(brand);
 
   const error =
-    vaultLoadingErrors.get(id) ||
+    vaultManagerLoadingErrors.get(id) ||
     (brand && priceErrors.get(brand)) ||
     vaultFactoryParamsLoadingError;
 

--- a/src/components/VaultSummary.tsx
+++ b/src/components/VaultSummary.tsx
@@ -1,0 +1,51 @@
+import { useMemo } from 'react';
+import { useVaultStore } from 'store/vaults';
+import { useAtomValue } from 'jotai';
+import { displayFunctionsAtom } from 'store/app';
+import type { VaultKey } from 'store/vaults';
+
+type Props = {
+  id: VaultKey;
+};
+
+const VaultSummary = ({ id }: Props) => {
+  const { vaults, errors } = useVaultStore(state => ({
+    vaults: state.vaults,
+    errors: state.vaultErrors,
+  }));
+  const vault = vaults.get(id);
+  const error = errors.get(id);
+  const displayFunctions = useAtomValue(displayFunctionsAtom);
+
+  return useMemo(() => {
+    assert(vault, `Cannot render summary for nonexistent vault ${id}`);
+    assert(
+      displayFunctions,
+      `Cannot render summary for vault ${id} - missing vbank asset info.`,
+    );
+    const { displayAmount, displayBrandPetname } = displayFunctions;
+
+    if (error) {
+      return (
+        <div className="p-4 pt-2 border border-black border-solid">
+          <h3>{id}</h3>
+          <p>Error: {error.toString()}</p>
+        </div>
+      );
+    }
+
+    // TODO: Calculate and display total debt correctly.
+    return (
+      <div className="p-4 pt-2 border border-black border-solid">
+        <h3>{id}</h3>
+        <p>Status: {vault.vaultState}</p>
+        <p>
+          Locked: {displayAmount(vault.locked)}{' '}
+          {displayBrandPetname(vault.locked.brand)}
+        </p>
+      </div>
+    );
+  }, [vault, error, id, displayFunctions]);
+};
+
+export default VaultSummary;

--- a/src/components/VaultSummary.tsx
+++ b/src/components/VaultSummary.tsx
@@ -5,30 +5,30 @@ import { displayFunctionsAtom } from 'store/app';
 import type { VaultKey } from 'store/vaults';
 
 type Props = {
-  id: VaultKey;
+  vaultKey: VaultKey;
 };
 
-const VaultSummary = ({ id }: Props) => {
+const VaultSummary = ({ vaultKey }: Props) => {
   const { vaults, errors } = useVaultStore(state => ({
     vaults: state.vaults,
     errors: state.vaultErrors,
   }));
-  const vault = vaults.get(id);
-  const error = errors.get(id);
+  const vault = vaults.get(vaultKey);
+  const error = errors.get(vaultKey);
   const displayFunctions = useAtomValue(displayFunctionsAtom);
 
   return useMemo(() => {
-    assert(vault, `Cannot render summary for nonexistent vault ${id}`);
+    assert(vault, `Cannot render summary for nonexistent vault ${vaultKey}`);
     assert(
       displayFunctions,
-      `Cannot render summary for vault ${id} - missing vbank asset info.`,
+      `Cannot render summary for vault ${vaultKey} - missing vbank asset info.`,
     );
     const { displayAmount, displayBrandPetname } = displayFunctions;
 
     if (error) {
       return (
         <div className="p-4 pt-2 border border-black border-solid">
-          <h3>{id}</h3>
+          <h3>{vaultKey}</h3>
           <p>Error: {error.toString()}</p>
         </div>
       );
@@ -37,7 +37,7 @@ const VaultSummary = ({ id }: Props) => {
     // TODO: Calculate and display total debt correctly.
     return (
       <div className="p-4 pt-2 border border-black border-solid">
-        <h3>{id}</h3>
+        <h3>{vaultKey}</h3>
         <p>Status: {vault.vaultState}</p>
         <p>
           Locked: {displayAmount(vault.locked)}{' '}
@@ -45,7 +45,7 @@ const VaultSummary = ({ id }: Props) => {
         </p>
       </div>
     );
-  }, [vault, error, id, displayFunctions]);
+  }, [vault, error, vaultKey, displayFunctions]);
 };
 
 export default VaultSummary;

--- a/src/store/vaults.ts
+++ b/src/store/vaults.ts
@@ -39,32 +39,53 @@ export type VaultFactoryParams = {
   minInitialDebt: Amount<'nat'>;
 };
 
+export type VaultInfoChainData = {
+  debtSnapShot: {
+    debt: Amount<'nat'>;
+    interest: Ratio;
+  };
+  locked: Amount<'nat'>;
+  vaultState: string;
+};
+
+export type VaultInfo = VaultInfoChainData & {
+  managerId: string;
+};
+
+type VaultKey = string;
+export const keyForVault = (managerId: string, vaultId: string) =>
+  `${managerId}.${vaultId}` as VaultKey;
+
 interface VaultState {
-  vaultIdsLoadingError: string | null;
+  managerIdsLoadingError: string | null;
   vaultFactoryParamsLoadingError: string | null;
   vaultFactoryInstanceHandleLoadingError: string | null;
-  vaultLoadingErrors: Map<string, unknown>;
+  vaultManagerLoadingErrors: Map<string, unknown>;
   vaultManagerIds: string[] | null;
   vaultManagers: Map<string, VaultManager>;
   vaultGovernedParams: Map<string, VaultParams>;
   vaultMetrics: Map<string, VaultMetrics>;
+  vaults: Map<VaultKey, VaultInfo>;
+  vaultErrors: Map<VaultKey, unknown>;
   prices: Map<Brand, PriceDescription>;
   priceErrors: Map<Brand, unknown>;
   vaultFactoryParams: VaultFactoryParams | null;
   vaultFactoryInstanceHandle: unknown;
   setPrice: (brand: Brand, price: PriceDescription) => void;
   setPriceError: (brand: Brand, e: unknown) => void;
-  setVaultLoadingError: (id: string, error: unknown) => void;
+  setVaultManagerLoadingError: (id: string, error: unknown) => void;
   setVaultManager: (id: string, manager: VaultManager) => void;
   setVaultGovernedParams: (id: string, params: VaultParams) => void;
   setVaultMetrics: (id: string, metrics: VaultMetrics) => void;
+  setVault: (key: VaultKey, vault: VaultInfo) => void;
+  setVaultError: (key: VaultKey, error: unknown) => void;
 }
 
 export const useVaultStore = create<VaultState>()(set => ({
-  vaultIdsLoadingError: null,
+  managerIdsLoadingError: null,
   vaultFactoryParamsLoadingError: null,
   vaultFactoryInstanceHandleLoadingError: null,
-  vaultLoadingErrors: new Map(),
+  vaultManagerLoadingErrors: new Map(),
   vaultManagerIds: null,
   vaultManagers: new Map(),
   vaultFactoryParams: null,
@@ -73,11 +94,13 @@ export const useVaultStore = create<VaultState>()(set => ({
   vaultMetrics: new Map<string, VaultMetrics>(),
   prices: new Map<Brand, PriceDescription>(),
   priceErrors: new Map<Brand, unknown>(),
-  setVaultLoadingError: (id: string, error: unknown) =>
+  vaults: new Map<VaultKey, VaultInfo>(),
+  vaultErrors: new Map<VaultKey, unknown>(),
+  setVaultManagerLoadingError: (id: string, error: unknown) =>
     set(state => {
-      const newErrors = new Map(state.vaultLoadingErrors);
+      const newErrors = new Map(state.vaultManagerLoadingErrors);
       newErrors.set(id, error);
-      return { vaultLoadingErrors: newErrors };
+      return { vaultManagerLoadingErrors: newErrors };
     }),
   setVaultManager: (id: string, manager: VaultManager) =>
     set(state => {
@@ -108,5 +131,17 @@ export const useVaultStore = create<VaultState>()(set => ({
       const newPriceErrors = new Map(state.priceErrors);
       newPriceErrors.set(brand, e);
       return { priceErrors: newPriceErrors };
+    }),
+  setVault: (key: VaultKey, vault: VaultInfo) =>
+    set(state => {
+      const newVaults = new Map(state.vaults);
+      newVaults.set(key, vault);
+      return { vaults: newVaults };
+    }),
+  setVaultError: (key: VaultKey, e: unknown) =>
+    set(state => {
+      const newVaultErrors = new Map(state.vaultErrors);
+      newVaultErrors.set(key, e);
+      return { vaultErrors: newVaultErrors };
     }),
 }));

--- a/src/store/vaults.ts
+++ b/src/store/vaults.ts
@@ -40,7 +40,7 @@ export type VaultFactoryParams = {
 };
 
 export type VaultInfoChainData = {
-  debtSnapShot: {
+  debtSnapshot: {
     debt: Amount<'nat'>;
     interest: Ratio;
   };
@@ -52,7 +52,7 @@ export type VaultInfo = VaultInfoChainData & {
   managerId: string;
 };
 
-type VaultKey = string;
+export type VaultKey = string;
 export const keyForVault = (managerId: string, vaultId: string) =>
   `${managerId}.${vaultId}` as VaultKey;
 

--- a/src/views/Vaults.tsx
+++ b/src/views/Vaults.tsx
@@ -18,15 +18,15 @@ const Vaults = () => {
     };
   }, [leader, netConfig]);
 
-  const { vaultIdsLoadingError, vaultManagerIds } = useVaultStore();
+  const { managerIdsLoadingError, vaultManagerIds } = useVaultStore();
   const { watchVbankError, brandToInfo } = useAtomValue(appAtom);
 
   return (
     <>
       <h1>Vaults</h1>
-      {vaultIdsLoadingError && <div>{vaultIdsLoadingError}</div>}
+      {managerIdsLoadingError && <div>{managerIdsLoadingError}</div>}
       {watchVbankError && <div>{watchVbankError}</div>}
-      {!vaultIdsLoadingError &&
+      {!managerIdsLoadingError &&
         !watchVbankError &&
         !(vaultManagerIds && brandToInfo) && (
           <div>Loading collateral choices...</div>

--- a/src/views/Vaults.tsx
+++ b/src/views/Vaults.tsx
@@ -1,13 +1,20 @@
 import { useAtomValue } from 'jotai';
 import { appAtom, leaderAtom, networkConfigAtom } from 'store/app';
-import { useEffect } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { watchVaultFactory } from 'service/vaults';
 import CollateralChoices from 'components/CollateralChoices';
+import ManageVaults from 'components/ManageVaults';
 import { useVaultStore } from 'store/vaults';
+
+const Modes = {
+  create: 0,
+  manage: 1,
+};
 
 const Vaults = () => {
   const netConfig = useAtomValue(networkConfigAtom);
   const leader = useAtomValue(leaderAtom);
+  const [mode, setMode] = useState(Modes.create);
 
   useEffect(() => {
     if (!leader) return;
@@ -21,17 +28,68 @@ const Vaults = () => {
   const { managerIdsLoadingError, vaultManagerIds } = useVaultStore();
   const { watchVbankError, brandToInfo } = useAtomValue(appAtom);
 
-  return (
+  const create = (
     <>
-      <h1>Vaults</h1>
-      {managerIdsLoadingError && <div>{managerIdsLoadingError}</div>}
-      {watchVbankError && <div>{watchVbankError}</div>}
       {!managerIdsLoadingError &&
         !watchVbankError &&
         !(vaultManagerIds && brandToInfo) && (
           <div>Loading collateral choices...</div>
         )}
       {vaultManagerIds && brandToInfo && <CollateralChoices />}
+    </>
+  );
+
+  const manage = <ManageVaults />;
+
+  const buttonText = (() => {
+    switch (mode) {
+      case Modes.create:
+        return 'Back to Manage Vaults';
+      case Modes.manage:
+        return 'Add New Vault';
+      default:
+        return 'Manage Vaults';
+    }
+  })();
+
+  const content = (() => {
+    switch (mode) {
+      case Modes.create:
+        return create;
+      case Modes.manage:
+        return manage;
+      default:
+        return create;
+    }
+  })();
+
+  const switchMode = useCallback(() => {
+    switch (mode) {
+      case Modes.create:
+        setMode(Modes.manage);
+        break;
+      case Modes.manage:
+        setMode(Modes.create);
+        break;
+      default:
+        setMode(Modes.manage);
+    }
+  }, [mode]);
+
+  return (
+    <>
+      <h1>Vaults</h1>
+      <div className="w-full flex justify-end">
+        <button
+          className="text-gray-50 font-medium text-xs uppercase flex flex-row justify-center items-center p-3 bg-purple-400 rounded-md"
+          onClick={switchMode}
+        >
+          {buttonText}
+        </button>
+      </div>
+      {managerIdsLoadingError && <div>{managerIdsLoadingError}</div>}
+      {watchVbankError && <div>{watchVbankError}</div>}
+      {content}
     </>
   );
 };


### PR DESCRIPTION
refs https://github.com/Agoric/dapp-inter/issues/13
refs https://github.com/Agoric/dapp-inter/issues/12

The loading states for the  "Manage Vaults" view could be handled a little smoother. Right now the vaults just pop up as each one loads individually, async. This can be improved on further when we can load *only* the user's vaults (https://github.com/Agoric/agoric-sdk/issues/6665), since a lot of this code will need to be rewritten then.

For now this just establishes some basic vault loading/rendering:
![image](https://user-images.githubusercontent.com/8848650/212275420-71990986-0465-41f9-8fb9-726c82afb269.png)
