### PR TITLE
fix: restore import context patch

### DIFF
--- a/patches/@agoric+smart-wallet+0.4.3-dev-1adb7a2.0.patch
+++ b/patches/@agoric+smart-wallet+0.4.3-dev-1adb7a2.0.patch
@@ -1,0 +1,14 @@
+diff --git a/node_modules/@agoric/smart-wallet/src/marshal-contexts.js b/node_modules/@agoric/smart-wallet/src/marshal-contexts.js
+index 4fcc880..aa12e55 100644
+--- a/node_modules/@agoric/smart-wallet/src/marshal-contexts.js
++++ b/node_modules/@agoric/smart-wallet/src/marshal-contexts.js
+@@ -288,7 +288,8 @@ export const makeImportContext = (makePresence = defaultMakePresence) => {
+      * @param {string} iface
+      */
+     fromBoard: (slot, iface) => {
+-      isBoardId(slot) || Fail`bad board slot ${q(slot)}`;
++      // The UI shouldn't error on null board slots, just return a null value.
++      isBoardId(slot) || slot === null || Fail`bad board slot ${q(slot)}`;
+       return provideVal(boardObjects, slot, iface);
+     },
+ 


### PR DESCRIPTION
Using patch-package still just to unblock and because I'm not sure if we want the version used by the smart wallet to be null-friendly.