### PR TITLE
build: cleaner ipfs comment

### DIFF
--- a/.github/workflows/deploy-inter.yml
+++ b/.github/workflows/deploy-inter.yml
@@ -48,7 +48,4 @@ jobs:
         message: |
           IPFS hash: `${{ steps.ipfs.outputs.ipfs }}`
           IPFS v1 hash: `${{ steps.ipfsv1.outputs.v1hash }}`
-          Gateways: 
-          - https://${{ steps.ipfsv1.outputs.v1hash }}.ipfs.cf-ipfs.com/
-          - https://${{ steps.ipfsv1.outputs.v1hash }}.ipfs.dweb.link/
-          - https://${{ steps.ipfsv1.outputs.v1hash }}.ipfs.4everland.io/
+          [CF](https://${{ steps.ipfsv1.outputs.v1hash }}.ipfs.cf-ipfs.com) - [DWeb](https://${{ steps.ipfsv1.outputs.v1hash }}.ipfs.dweb.link) - [4EVERLAND](https://${{ steps.ipfsv1.outputs.v1hash }}.ipfs.4everland.io)


### PR DESCRIPTION
I found the long urls in the IPFS comment distracting.

**Before**
<img width="857" alt="Screenshot 2023-02-10 at 7 39 32 AM" src="https://user-images.githubusercontent.com/21505/218132592-86094378-3c9a-4370-b28c-d92d1e2599c4.png">

**After**
<img width="849" alt="Screenshot 2023-02-10 at 7 41 15 AM" src="https://user-images.githubusercontent.com/21505/218132993-a02943dc-2113-4fc9-9a0d-85d7f024dc1c.png">
