### PR TITLE
fix: use max debt limit

### DIFF
--- a/src/service/vaults.ts
+++ b/src/service/vaults.ts
@@ -13,7 +13,6 @@ import type { Brand, Amount } from '@agoric/ertp/src/types';
 import type { Ratio, PriceQuote } from 'store/vaults';
 import { calculateMinimumCollateralization } from '@agoric/inter-protocol/src/vaultFactory/math';
 import { CollateralAction, DebtAction } from 'store/adjustVault';
-import { AmountMath } from '@agoric/ertp';
 
 type ValuePossessor<T> = {
   value: T;
@@ -206,6 +205,7 @@ export const watchVaultFactory = (netconfigUrl: string) => {
       const liquidationMargin = current.LiquidationMargin.value;
       const liquidationPadding = current.LiquidationPadding.value;
       const loanFee = current.LoanFee.value;
+      const debtLimit = current.DebtLimit.value;
 
       const inferredMinimumCollateralization =
         calculateMinimumCollateralization(
@@ -213,19 +213,8 @@ export const watchVaultFactory = (netconfigUrl: string) => {
           liquidationPadding,
         );
 
-      const debtLimit = current.DebtLimit.value;
-
-      // The real debt limit can actually never be reached, only 1 less than
-      // the debt limit can be enforced by the contract.
-      //
-      // AFTER: https://github.com/Agoric/agoric-sdk/issues/6969 remove this.
-      const effectiveDebtLimit =
-        debtLimit.value > 0n
-          ? AmountMath.make(debtLimit.brand, debtLimit.value - 1n)
-          : current.DebtLimit.value;
-
       useVaultStore.getState().setVaultGovernedParams(id, {
-        debtLimit: effectiveDebtLimit,
+        debtLimit,
         interestRate,
         liquidationMargin,
         liquidationPenalty,

--- a/src/store/createVault.ts
+++ b/src/store/createVault.ts
@@ -118,6 +118,7 @@ export const valueToReceiveAtom = atom(
           value,
           defaultCollateralizationRatio,
           loanFee,
+          'ceil',
         ),
       );
     }
@@ -194,6 +195,7 @@ export const selectedCollateralIdAtom = atom(
         defaultValueReceived.value,
         defaultCollateralizationRatio,
         loanFee,
+        'ceil',
       );
       set(valueToLockInternal, valueToLock);
     } else {

--- a/src/utils/vaultMath.ts
+++ b/src/utils/vaultMath.ts
@@ -49,8 +49,6 @@ export const computeToLock = (
   toReceive: NatValue,
   defaultCollateralization: Ratio,
   loanFee: Ratio,
-  // Round up by default to preserve offer safety. But, if using this to set
-  // max input, round down to avoid hitting debt limit.
   remainderHandling: 'floor' | 'ceil' = 'floor',
 ): NatValue => {
   const multiply =

--- a/src/utils/vaultMath.ts
+++ b/src/utils/vaultMath.ts
@@ -51,10 +51,11 @@ export const computeToLock = (
   loanFee: Ratio,
   // Round up by default to preserve offer safety. But, if using this to set
   // max input, round down to avoid hitting debt limit.
-  roundDown: boolean = false,
+  remainderHandling: 'floor' | 'ceil' = 'floor',
 ): NatValue => {
-  const multiply = roundDown ? floorMultiplyBy : ceilMultiplyBy;
-  const divide = roundDown ? floorDivideBy : ceilDivideBy;
+  const multiply =
+    remainderHandling === 'floor' ? floorMultiplyBy : ceilMultiplyBy;
+  const divide = remainderHandling === 'floor' ? floorDivideBy : ceilDivideBy;
 
   const collateralizationRatioOrDefault =
     collateralizationRatio.numerator.value === 0n
@@ -165,7 +166,7 @@ export const maxCollateralForNewVault = (
     istAvailableBeforeLoanFee.value,
     desiredCollateralization,
     loanFee,
-    true,
+    'floor',
   );
 
   return AmountMath.min(

--- a/test/utils/vaultMath.test.ts
+++ b/test/utils/vaultMath.test.ts
@@ -230,32 +230,30 @@ describe('istAvailable', () => {
 
 describe('maxCollateralForNewVault', () => {
   it('should prevent the user from exceeding the mint limit', () => {
-    // Effective limit on new debt is 40n.
     const [debtLimit, totalDebt] = [
-      AmountMath.make(mintedBrand, 100n),
-      AmountMath.make(mintedBrand, 60n),
+      AmountMath.make(mintedBrand, 999_999_999n),
+      AmountMath.make(mintedBrand, 115_516_666n),
     ];
 
-    // Loan fee is 10%.
+    // Loan fee is 1%.
     const loanFee = makeRatioFromAmounts(
       AmountMath.make(mintedBrand, 10n),
-      AmountMath.make(mintedBrand, 100n),
+      AmountMath.make(mintedBrand, 1000n),
     );
 
-    // Price: 10 Collateral = 1 Minted
     const priceRate = {
-      amountIn: AmountMath.make(collateralBrand, 1000n),
-      amountOut: AmountMath.make(mintedBrand, 100n),
+      amountIn: AmountMath.make(collateralBrand, 10_000n),
+      amountOut: AmountMath.make(mintedBrand, 7_100_000n),
     };
 
     // 150%
     const minCollateralization = makeRatioFromAmounts(
-      AmountMath.make(mintedBrand, 150n),
-      AmountMath.make(mintedBrand, 100n),
+      AmountMath.make(mintedBrand, 1500n),
+      AmountMath.make(mintedBrand, 1000n),
     );
 
     // Ample funds in purse.
-    const collateralPurseBalance = AmountMath.make(mintedBrand, 999n);
+    const collateralPurseBalance = AmountMath.make(mintedBrand, 2_000_000n);
 
     expect(
       maxCollateralForNewVault(
@@ -266,7 +264,7 @@ describe('maxCollateralForNewVault', () => {
         minCollateralization,
         collateralPurseBalance,
       ),
-    ).toEqual(600n);
+    ).toEqual(1_868_626n);
   });
 
   it('should prevent the user from exceeding their collateral purse balance', () => {

--- a/test/utils/vaultMath.test.ts
+++ b/test/utils/vaultMath.test.ts
@@ -41,6 +41,7 @@ describe('computeToLock', () => {
         toReceive,
         collateralizationRatio,
         loanFee,
+        'ceil',
       ),
     ).toEqual(10670n);
   });


### PR DESCRIPTION
- Use full debt limit now that we have: https://github.com/Agoric/agoric-sdk/pull/6984
- Fix rounding error for "max" button in vault creation and added test.