### PR TITLE
feat: allow queryparam netselect

### DIFF
--- a/src/components/NetworkDropdown.tsx
+++ b/src/components/NetworkDropdown.tsx
@@ -32,9 +32,11 @@ const Item = ({
 
 const NetworkDropdown = () => {
   const [networkConfig, setNetworkConfig] = useAtom(networkConfigAtom);
-  const specifiedNetworkName = new URLSearchParams(window.location.search).get('network');
+  const specifiedNetworkName = new URLSearchParams(window.location.search).get(
+    'network',
+  );
   if (specifiedNetworkName !== null) {
-    if (specifiedNetworkName in networkConfigs){
+    if (specifiedNetworkName in networkConfigs) {
       setNetworkConfig((networkConfigs as never)[specifiedNetworkName]);
       const prevSearch = new URLSearchParams(window.location.search);
       prevSearch.delete('network');
@@ -43,7 +45,7 @@ const NetworkDropdown = () => {
       console.error('invalid network requested', specifiedNetworkName);
     }
   }
-  
+
   const items = Object.values(networkConfigs).map(config => (
     <Item
       key={config.url}

--- a/src/components/NetworkDropdown.tsx
+++ b/src/components/NetworkDropdown.tsx
@@ -33,11 +33,15 @@ const Item = ({
 const NetworkDropdown = () => {
   const [networkConfig, setNetworkConfig] = useAtom(networkConfigAtom);
   const specifiedNetworkName = new URLSearchParams(window.location.search).get('network');
-  if (specifiedNetworkName !== null && specifiedNetworkName in networkConfigs) {
-    setNetworkConfig((networkConfigs as never)[specifiedNetworkName]);
-    const prevSearch = new URLSearchParams(window.location.search);
-    prevSearch.delete('network');
-    window.location.replace(`?${prevSearch}`);
+  if (specifiedNetworkName !== null) {
+    if (specifiedNetworkName in networkConfigs){
+      setNetworkConfig((networkConfigs as never)[specifiedNetworkName]);
+      const prevSearch = new URLSearchParams(window.location.search);
+      prevSearch.delete('network');
+      window.location.replace(`?${prevSearch}`);
+    } else {
+      console.error('invalid network requested', specifiedNetworkName);
+    }
   }
   
   const items = Object.values(networkConfigs).map(config => (

--- a/src/components/NetworkDropdown.tsx
+++ b/src/components/NetworkDropdown.tsx
@@ -32,7 +32,14 @@ const Item = ({
 
 const NetworkDropdown = () => {
   const [networkConfig, setNetworkConfig] = useAtom(networkConfigAtom);
-
+  const specifiedNetworkName = new URLSearchParams(window.location.search).get('network');
+  if (specifiedNetworkName !== null && specifiedNetworkName in networkConfigs) {
+    setNetworkConfig((networkConfigs as never)[specifiedNetworkName]);
+    const prevSearch = new URLSearchParams(window.location.search);
+    prevSearch.delete('network');
+    window.location.replace(`?${prevSearch}`);
+  }
+  
   const items = Object.values(networkConfigs).map(config => (
     <Item
       key={config.url}

--- a/src/config.ts
+++ b/src/config.ts
@@ -11,6 +11,14 @@ export const networkConfigs = {
     label: 'Agoric Emerynet',
     url: 'https://emerynet.agoric.net/network-config',
   },
+  xnet: {
+    label: 'Agoric Xnet',
+    url: 'https://xnet.agoric.net/network-config',
+  },
+  loadtest: {
+    label: 'Agoric Loadtest',
+    url: 'https://loadtest.agoric.net/network-config',
+  },
   localhost: {
     label: 'Local Network',
     url: 'https://wallet.agoric.app/wallet/network-config',


### PR DESCRIPTION
Allows a `network=ollinet` or default for network selection