### PR TITLE
fix: convert entries from wallet

### DIFF
--- a/src/service/wallet.ts
+++ b/src/service/wallet.ts
@@ -37,8 +37,11 @@ export const watchPublicSubscribers = (chainConnection: ChainConnection) => {
   const watch = async () => {
     const n = chainConnection.publicSubscribersNotifier;
 
-    for await (const offerIdsToPublicSubscribers of iterateNotifier(n)) {
+    for await (const entries of iterateNotifier(n)) {
       if (isCancelled) return;
+      if (!entries) continue;
+
+      const offerIdsToPublicSubscribers = Object.fromEntries(entries);
       console.debug(
         'got offer ids to public subscribers',
         offerIdsToPublicSubscribers,


### PR DESCRIPTION
Vaults weren't loading because we changed the wallet to publish an array of entries rather than a record for its public subscribers [#Agoric/agoric-sdk/7139](https://github.com/Agoric/agoric-sdk/pull/7139). This updates the UI to view parse them correctly.