### PR TITLE
feat: support new managers vstorage path

### DIFF
--- a/src/service/vaults.ts
+++ b/src/service/vaults.ts
@@ -289,13 +289,21 @@ export const watchVaultFactory = (netconfigUrl: string) => {
     }
     if (isStopped) return;
 
-    let managerIds;
+    let managerIds: string[];
     try {
+      // old way (deprecated since https://github.com/Agoric/agoric-sdk/pull/7150)
       managerIds = await fetchVstorageKeys(rpc, 'published.vaultFactory').then(
         res =>
           (res.children as string[]).filter(key => key.startsWith('manager')),
       );
       assert(managerIds);
+      if (managerIds.length === 0) {
+        // new way
+        managerIds = await fetchVstorageKeys(
+          rpc,
+          'published.vaultFactory.managers',
+        ).then(res => res.children);
+      }
     } catch (e) {
       if (isStopped) return;
       const msg = 'Error fetching vault managers';


### PR DESCRIPTION
required for https://github.com/Agoric/agoric-sdk/pull/7150

Support both before and after schemes. We can drop support for the old scheme when it's known not to be served.