### PR TITLE
feat: account for locked price in creation and adjustment

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,8 +6,13 @@ import Vaults from 'views/Vaults';
 import ErrorPage from 'views/ErrorPage';
 import { useEffect } from 'react';
 import { watchVbank } from 'service/vbank';
-import { useAtomValue, useAtom } from 'jotai';
-import { leaderAtom, networkConfigAtom } from 'store/app';
+import { useAtomValue, useAtom, useSetAtom } from 'jotai';
+import {
+  currentTimeAtom,
+  leaderAtom,
+  networkConfigAtom,
+  secondsSinceEpoch,
+} from 'store/app';
 import { makeLeader } from '@agoric/casting';
 import Root from 'views/Root';
 import DisclaimerDialog from 'components/DisclaimerDialog';
@@ -30,6 +35,18 @@ const router = createHashRouter([
     ],
   },
 ]);
+
+const useTimeKeeper = () => {
+  const setCurrentTime = useSetAtom(currentTimeAtom);
+
+  useEffect(() => {
+    const id = setInterval(() => setCurrentTime(secondsSinceEpoch()), 950);
+
+    return () => {
+      clearInterval(id);
+    };
+  }, [setCurrentTime]);
+};
 
 const App = () => {
   const netConfig = useAtomValue(networkConfigAtom);
@@ -56,6 +73,8 @@ const App = () => {
       isCancelled = true;
     };
   }, [setError, leader, netConfig, setLeader]);
+
+  useTimeKeeper();
 
   return (
     <div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,15 +7,11 @@ import ErrorPage from 'views/ErrorPage';
 import { useEffect } from 'react';
 import { watchVbank } from 'service/vbank';
 import { useAtomValue, useAtom, useSetAtom } from 'jotai';
-import {
-  currentTimeAtom,
-  leaderAtom,
-  networkConfigAtom,
-  secondsSinceEpoch,
-} from 'store/app';
+import { currentTimeAtom, leaderAtom, networkConfigAtom } from 'store/app';
 import { makeLeader } from '@agoric/casting';
 import Root from 'views/Root';
 import DisclaimerDialog from 'components/DisclaimerDialog';
+import { secondsSinceEpoch } from 'utils/date';
 
 import 'react-toastify/dist/ReactToastify.css';
 import 'styles/globals.css';
@@ -36,11 +32,16 @@ const router = createHashRouter([
   },
 ]);
 
+const TIME_UPDATE_INTERVAL_MS = 1000;
+
 const useTimeKeeper = () => {
   const setCurrentTime = useSetAtom(currentTimeAtom);
 
   useEffect(() => {
-    const id = setInterval(() => setCurrentTime(secondsSinceEpoch()), 950);
+    const id = setInterval(
+      () => setCurrentTime(secondsSinceEpoch()),
+      TIME_UPDATE_INTERVAL_MS,
+    );
 
     return () => {
       clearInterval(id);

--- a/src/components/AdjustVault.tsx
+++ b/src/components/AdjustVault.tsx
@@ -1,6 +1,6 @@
 import { useAtomValue, useSetAtom } from 'jotai';
 import { displayFunctionsAtom } from 'store/app';
-import { ViewMode, viewModeAtom } from 'store/vaults';
+import { ViewMode, useVaultStore, viewModeAtom } from 'store/vaults';
 import VaultSymbol from 'svg/vault-symbol';
 import clsx from 'clsx';
 import AdjustVaultForm from './AdjustVaultForm';
@@ -8,6 +8,7 @@ import AdjustVaultSummary from './AdjustVaultSummary';
 import { useCallback } from 'react';
 import { netValue } from 'utils/vaultMath';
 import { vaultToAdjustAtom } from 'store/adjustVault';
+import { useAuctionTimer } from 'utils/hooks';
 
 const AdjustVault = () => {
   const displayFunctions = useAtomValue(displayFunctionsAtom);
@@ -21,6 +22,10 @@ const AdjustVault = () => {
     displayAmount,
     displayBrandPetname,
   } = displayFunctions;
+
+  const { schedule } = useVaultStore(vaults => ({
+    schedule: vaults.liquidationSchedule,
+  }));
 
   const setMode = useSetAtom(viewModeAtom);
 
@@ -38,6 +43,7 @@ const AdjustVault = () => {
     collateralPrice,
     totalLockedValue,
     totalDebt,
+    lockedPrice,
   } = vaultToAdjust;
 
   const [netVaultValue, isNetValueNegative] = netValue(
@@ -47,6 +53,8 @@ const AdjustVault = () => {
 
   // TODO: Update dynamically.
   const vaultLabel = 'ATOM';
+
+  const auctionTimer = useAuctionTimer(schedule);
 
   return (
     <>
@@ -68,6 +76,23 @@ const AdjustVault = () => {
               {displayPriceTimestamp(collateralPrice)}
             </span>
           </div>
+          {lockedPrice && (
+            <div>
+              Next Liquidation Price:{' '}
+              <span className="font-medium text-lg whitespace-nowrap">
+                {displayPrice({
+                  amountIn: lockedPrice.denominator,
+                  amountOut: lockedPrice.numerator,
+                })}
+              </span>
+              {auctionTimer && (
+                <>
+                  {' - '}
+                  <span className="italic">{auctionTimer}</span>
+                </>
+              )}
+            </div>
+          )}
         </div>
       </div>
       <div className="mt-6 rounded-[10px] p-4 px-8 flex justify-between flex-wrap gap-8 bg-[#FFF4C0]">

--- a/src/components/AdjustVaultForm.tsx
+++ b/src/components/AdjustVaultForm.tsx
@@ -72,7 +72,8 @@ const AdjustVaultForm = () => {
       return;
     }
 
-    const { params, metrics, totalDebt, collateralPrice } = vaultToAdjust;
+    const { params, metrics, totalDebt, collateralPrice, lockedPrice } =
+      vaultToAdjust;
     const { newLocked } = vaultAfterAdjustment;
 
     setDebtInputValue(
@@ -84,6 +85,7 @@ const AdjustVaultForm = () => {
         newLocked,
         collateralPrice,
         params.inferredMinimumCollateralization,
+        lockedPrice,
       ),
     );
   };

--- a/src/components/VaultSummary.tsx
+++ b/src/components/VaultSummary.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useState } from 'react';
 import { useVaultStore, vaultKeyToAdjustAtom } from 'store/vaults';
-import { displayFunctionsAtom } from 'store/app';
+import { currentTimeAtom, displayFunctionsAtom } from 'store/app';
 import { calculateCurrentDebt } from '@agoric/inter-protocol/src/interest-math';
 import {
   ceilMultiplyBy,
@@ -191,6 +191,8 @@ const VaultSummary = ({ vaultKey }: Props) => {
     books: state.liquidationAuctionBooks,
   }));
 
+  const currentTime = useAtomValue(currentTimeAtom);
+
   const vault = vaults?.get(vaultKey);
   assert(vault, `Cannot render summary for nonexistent vault ${vaultKey}`);
 
@@ -333,9 +335,6 @@ const VaultSummary = ({ vaultKey }: Props) => {
       (isLiquidationPriceBelowOraclePrice ||
         isLiquidationPriceBelowNextAuctionPrice) &&
       !isLiquidating;
-
-    // Seconds since epoch.
-    const currentTime = new Date().getTime() / 1000;
 
     const isLiquidationImminent =
       isLiquidationPriceBelowNextAuctionPrice &&
@@ -551,6 +550,7 @@ const VaultSummary = ({ vaultKey }: Props) => {
     displayFunctions,
     liquidationSchedule,
     book,
+    currentTime,
     isCloseVaultDialogOpen,
     setCollateralAction,
     setDebtAction,

--- a/src/service/vaults.ts
+++ b/src/service/vaults.ts
@@ -295,6 +295,7 @@ export const watchVaultFactory = (netconfigUrl: string) => {
       f,
     )) {
       if (isStopped) break;
+      console.debug('got update', path, value);
       useVaultStore.getState().setLiquidationAuctionBook(id, value);
     }
   };

--- a/src/store/adjustVault.ts
+++ b/src/store/adjustVault.ts
@@ -36,11 +36,19 @@ type VaultToAdjust = {
   collateralizationRatio?: Ratio;
   createdByOfferId: string;
   vaultState?: VaultPhase;
+  lockedPrice?: Ratio;
 };
 
 export const vaultToAdjustAtom = atom<VaultToAdjust | null>(get => {
-  const { vaults, vaultManagers, prices, vaultGovernedParams, vaultMetrics } =
-    get(vaultStoreAtom);
+  const {
+    vaults,
+    vaultManagers,
+    prices,
+    vaultGovernedParams,
+    vaultMetrics,
+    liquidationAuctionBooks,
+    liquidationSchedule,
+  } = get(vaultStoreAtom);
   const key = get(vaultKeyToAdjustAtom);
 
   const vault = key && vaults?.get(key);
@@ -57,6 +65,10 @@ export const vaultToAdjustAtom = atom<VaultToAdjust | null>(get => {
   if (!(locked && debtSnapshot && manager && price && params && metrics)) {
     return null;
   }
+
+  const lockedPrice = liquidationSchedule?.activeStartTime
+    ? undefined
+    : liquidationAuctionBooks.get(managerId)?.startPrice ?? undefined;
 
   const totalLockedValue = ceilMultiplyBy(
     locked,
@@ -84,6 +96,7 @@ export const vaultToAdjustAtom = atom<VaultToAdjust | null>(get => {
     collateralizationRatio,
     createdByOfferId,
     vaultState,
+    lockedPrice,
   };
 });
 

--- a/src/store/app.ts
+++ b/src/store/app.ts
@@ -18,6 +18,7 @@ import { makeWalletService } from 'service/wallet';
 import type { DisplayInfo, Brand, AssetKind } from '@agoric/ertp/src/types';
 import type { Leader } from '@agoric/casting';
 import type { PursesJSONState } from '@agoric/wallet-backend';
+import { secondsSinceEpoch } from 'utils/date';
 
 export type BrandInfo = DisplayInfo<'nat'> & {
   petname: string;
@@ -71,8 +72,6 @@ export const appStore = createStore<AppState>()(() => ({
 }));
 
 export const appAtom = atomWithStore(appStore);
-
-export const secondsSinceEpoch = () => new Date().getTime() / 1000;
 
 export const currentTimeAtom = atom(secondsSinceEpoch());
 

--- a/src/store/app.ts
+++ b/src/store/app.ts
@@ -72,6 +72,10 @@ export const appStore = createStore<AppState>()(() => ({
 
 export const appAtom = atomWithStore(appStore);
 
+export const secondsSinceEpoch = () => new Date().getTime() / 1000;
+
+export const currentTimeAtom = atom(secondsSinceEpoch());
+
 export const offerIdsToPublicSubscribersAtom = atom(
   get => get(appAtom).offerIdsToPublicSubscribers,
 );

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -1,0 +1,1 @@
+export const secondsSinceEpoch = () => new Date().getTime() / 1000;

--- a/src/utils/hooks.ts
+++ b/src/utils/hooks.ts
@@ -1,7 +1,8 @@
 import { useMemo } from 'react';
 import { useAtomValue } from 'jotai';
-import { displayFunctionsAtom, pursesAtom } from 'store/app';
+import { currentTimeAtom, displayFunctionsAtom, pursesAtom } from 'store/app';
 import type { Amount, Brand } from '@agoric/ertp/src/types';
+import { LiquidationSchedule } from 'store/vaults';
 
 export const usePurseBalanceDisplay = (brand?: Brand<'nat'> | null) => {
   const purses = useAtomValue(pursesAtom);
@@ -29,4 +30,27 @@ export const usePurseForBrand = (brand?: Brand<'nat'> | null) => {
   const purses = useAtomValue(pursesAtom);
 
   return purses?.find(p => p.brand === brand);
+};
+
+export const useAuctionTimer = (schedule: LiquidationSchedule | null) => {
+  const currentTime = useAtomValue(currentTimeAtom);
+
+  const minutesUntilNextAuction =
+    schedule?.nextStartTime &&
+    Math.max(
+      Math.floor((Number(schedule.nextStartTime.absValue) - currentTime) / 60),
+      0,
+    );
+
+  const secondsUntilNextAuction =
+    schedule?.nextStartTime &&
+    Math.max(
+      Math.floor((Number(schedule.nextStartTime.absValue) - currentTime) % 60),
+      0,
+    );
+
+  return minutesUntilNextAuction !== undefined &&
+    secondsUntilNextAuction !== undefined
+    ? `in ${minutesUntilNextAuction}m ${secondsUntilNextAuction}s`
+    : '';
 };

--- a/src/utils/vaultMath.ts
+++ b/src/utils/vaultMath.ts
@@ -33,7 +33,7 @@ export const isLiquidationPriceBelowGivenPrice = (
 };
 
 export const computeToLock = (
-  priceRate: Ratio,
+  quotePrice: Ratio,
   collateralizationRatio: Ratio,
   toReceive: NatValue,
   defaultCollateralization: Ratio,
@@ -60,7 +60,7 @@ export const computeToLock = (
     collateralizationRatioOrDefault,
   );
 
-  const priceToUse = lowestPrice(priceRate, lockedPrice);
+  const priceToUse = lowestPrice(quotePrice, lockedPrice);
 
   return divide(receiveMargin, priceToUse).value;
 };
@@ -181,12 +181,15 @@ export const maxIstToMintFromVault = (
 };
 
 export const collateralizationRatio = (
-  price: PriceDescription,
+  quotePrice: PriceDescription,
   locked: Amount<'nat'>,
   debt: Amount<'nat'>,
   lockedPrice?: Ratio,
 ) => {
-  const priceRatio = makeRatioFromAmounts(price.amountOut, price.amountIn);
+  const priceRatio = makeRatioFromAmounts(
+    quotePrice.amountOut,
+    quotePrice.amountIn,
+  );
   const priceToUse = lowestPrice(priceRatio, lockedPrice);
 
   const totalLockedValue = ceilMultiplyBy(locked, priceToUse);
@@ -199,11 +202,14 @@ export const collateralizationRatio = (
 export const currentCollateralization = (
   debtSnapshot: DebtSnapshot,
   compoundedInterest: Ratio,
-  price: PriceDescription,
+  quotePrice: PriceDescription,
   locked: Amount<'nat'>,
   lockedPrice?: Ratio,
 ): Ratio | undefined => {
-  const priceRatio = makeRatioFromAmounts(price.amountOut, price.amountIn);
+  const priceRatio = makeRatioFromAmounts(
+    quotePrice.amountOut,
+    quotePrice.amountIn,
+  );
   const priceToUse = lowestPrice(priceRatio, lockedPrice);
 
   const totalDebt = calculateCurrentDebt(


### PR DESCRIPTION
fixes #100 
fixes #101 

## Description

Makes the "max" button use the lowest of next liquidation/current quote price when creating and adjusting vaults, and enforces collat. ratio based on lowest price when creating a vault.

Shows next liquidation price during price lock period in creation and adjustment views:

![image](https://github.com/Agoric/dapp-inter/assets/8848650/45cb354f-bc77-45bb-9f74-da905e1ef178)


![Capture2](https://github.com/Agoric/dapp-inter/assets/8848650/ab69a14f-fd87-4a19-b13b-01e6d3361a8a)

## Testing

Tested manually throughout price lock periods on a local chain and added unit tests for new cases
