### PR TITLE
fix: rely on ids not ordering for batch query

### DIFF
--- a/src/rpc/src/batchQuery.ts
+++ b/src/rpc/src/batchQuery.ts
@@ -20,9 +20,9 @@ export const batchVstorageQuery = (
   const options = {
     method: 'POST',
     body: JSON.stringify(
-      paths.map(path => ({
+      paths.map((path, index) => ({
         jsonrpc: '2.0',
-        id: 1,
+        id: index,
         method: 'abci_query',
         params: { path: `/custom/vstorage/${path[0]}/${path[1]}` },
       })),
@@ -33,7 +33,9 @@ export const batchVstorageQuery = (
     .then(res => res.json())
     .then(res =>
       Object.fromEntries(
-        (Array.isArray(res) ? res : [res]).map((entry, index) => {
+        (Array.isArray(res) ? res : [res]).map(entry => {
+          const { id: index } = entry;
+
           if (entry.result.response.code) {
             return [
               pathToKey(paths[index]),

--- a/src/rpc/test/chainStorageWatcher.test.ts
+++ b/src/rpc/test/chainStorageWatcher.test.ts
@@ -35,8 +35,8 @@ describe('makeAgoricChainStorageWatcher', () => {
 
     fetch.mockResolvedValue(
       createFetchResponse([
-        { value: expected1, kind: AgoricChainStoragePathKind.Data },
-        { value: expected2, kind: AgoricChainStoragePathKind.Children },
+        { value: expected1, kind: AgoricChainStoragePathKind.Data, id: 0 },
+        { value: expected2, kind: AgoricChainStoragePathKind.Children, id: 1 },
       ]),
     );
 
@@ -63,7 +63,7 @@ describe('makeAgoricChainStorageWatcher', () => {
       body: JSON.stringify([
         {
           jsonrpc: '2.0',
-          id: 1,
+          id: 0,
           method: 'abci_query',
           params: { path: `/custom/vstorage/data/${path}` },
         },
@@ -84,6 +84,7 @@ describe('makeAgoricChainStorageWatcher', () => {
     fetch.mockResolvedValue(
       createFetchResponse([
         {
+          id: 0,
           value: expected1,
           kind: AgoricChainStoragePathKind.Data,
           blockHeight: 123,
@@ -110,6 +111,7 @@ describe('makeAgoricChainStorageWatcher', () => {
     fetch.mockResolvedValue(
       createFetchResponse([
         {
+          id: 0,
           value: expected2,
           kind: AgoricChainStoragePathKind.Data,
           blockHeight: 456,
@@ -129,6 +131,7 @@ describe('makeAgoricChainStorageWatcher', () => {
     fetch.mockResolvedValue(
       createFetchResponse([
         {
+          id: 0,
           value: expected1,
           kind: AgoricChainStoragePathKind.Children,
         },
@@ -154,6 +157,7 @@ describe('makeAgoricChainStorageWatcher', () => {
     fetch.mockResolvedValue(
       createFetchResponse([
         {
+          id: 0,
           value: expected2,
           kind: AgoricChainStoragePathKind.Children,
         },
@@ -172,6 +176,7 @@ describe('makeAgoricChainStorageWatcher', () => {
     fetch.mockResolvedValue(
       createFetchResponse([
         {
+          id: 0,
           value: null,
           kind: AgoricChainStoragePathKind.Children,
           code: 6,
@@ -199,6 +204,7 @@ describe('makeAgoricChainStorageWatcher', () => {
     fetch.mockResolvedValue(
       createFetchResponse([
         {
+          id: 0,
           value: expected1,
           kind: AgoricChainStoragePathKind.Children,
         },
@@ -234,12 +240,13 @@ const createFetchResponse = (
     blockHeight?: number;
     code?: number;
     log?: string;
+    id: number;
   }[],
 ) => ({
   json: () =>
     new Promise(res =>
       res(
-        values.map(({ kind, value, blockHeight, code = 0, log }) => {
+        values.map(({ kind, value, blockHeight, code = 0, log, id }) => {
           const data =
             kind === AgoricChainStoragePathKind.Children
               ? { children: value }
@@ -251,6 +258,7 @@ const createFetchResponse = (
                 };
 
           return {
+            id,
             result: {
               response: {
                 value: window.btoa(JSON.stringify(data)),


### PR DESCRIPTION
@gibson042 Pointed out that the ordering of responses is not guaranteed in batch queries, we should rely on the id field instead