### PR TITLE
fix: connect wallet button bugs

### DIFF
--- a/src/components/ConnectWalletButton.tsx
+++ b/src/components/ConnectWalletButton.tsx
@@ -53,13 +53,16 @@ const ConnectWalletButton = () => {
     return 'Connect Wallet';
   })();
 
+  const isDisabled = !chainStorageWatcher;
+
   return (
     <button
+      disabled={isDisabled}
       className={clsx(
         'transition uppercase box-border border-2 border-primary h-11 inline-flex items-center justify-center rounded w-44 py-2 bg-transparent text-xs font-black',
-        !isConnectionInProgress &&
-          !chainConnection &&
-          'hover:bg-black hover:bg-opacity-5',
+        !isConnectionInProgress && !chainConnection && !isDisabled
+          ? 'hover:bg-black hover:bg-opacity-5 cursor-pointer'
+          : 'cursor-default',
       )}
       onClick={() => walletService.connect()}
     >
@@ -67,7 +70,7 @@ const ConnectWalletButton = () => {
         {status}
         {isConnectionInProgress && (
           <div className="ml-1">
-            <Oval color="var(--color-primary)" height={18} width={18} />
+            <Oval color="rgb(var(--color-primary))" height={18} width={18} />
           </div>
         )}
       </>


### PR DESCRIPTION
- Don't let the user click connect until `chainStorageWatcher` is initialized (which happens after network config is fetched). That's because `makeAgoricWalletConnection` requires it.
- Fix the loading spinner animation. We changed the css variables and that broke the styles there.