### PR TITLE
feat: navigate to 'PSM' and 'Analytics' from the navigation bar

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -34,3 +34,7 @@ export const branchBridgeHref = (branchName: string) =>
 export const signerTarget = 'wallet';
 
 export const disclaimerHref = 'https://docs.inter.trade/disclaimer';
+
+export const psmHref = 'https://psm.inter.trade/';
+
+export const analyticsHref = 'https://info.inter.trade/';

--- a/src/views/Root.tsx
+++ b/src/views/Root.tsx
@@ -2,7 +2,7 @@ import { NavLink, Outlet, useLocation, Navigate } from 'react-router-dom';
 import ConnectWalletButton from '../components/ConnectWalletButton';
 import React, { Suspense } from 'react';
 import { HiExternalLink } from 'react-icons/hi';
-import { psmHref, analyticsHref } from "../config";
+import { psmHref, analyticsHref } from '../config';
 
 const NetworkDropdown = React.lazy(
   () => import('../components/NetworkDropdown'),
@@ -25,10 +25,10 @@ const NavItem = ({ label, href, isExternal = false }: NavItemProps) => {
         {({ isActive }) => (
           <>
             <div className="h-1.5"></div>
-              <span className="inline-flex items-center">
-                  <span className="m-2 font-bold">{label}</span>
-                  {isExternal && <HiExternalLink />}
-              </span>
+            <span className="inline-flex items-center">
+              <span className="m-2 font-bold">{label}</span>
+              {isExternal && <HiExternalLink />}
+            </span>
 
             <div
               className={
@@ -69,8 +69,12 @@ const Root = () => {
           <nav>
             <ul className="h-24 flex flex-row space-x-12">
               <NavItem label="Vaults" href="/vaults" />
-              <NavItem label="PSM" href={psmHref} isExternal={true}/>
-              <NavItem label="Analytics" href={analyticsHref} isExternal={true}/>
+              <NavItem label="PSM" href={psmHref} isExternal={true} />
+              <NavItem
+                label="Analytics"
+                href={analyticsHref}
+                isExternal={true}
+              />
             </ul>
           </nav>
         </div>

--- a/src/views/Root.tsx
+++ b/src/views/Root.tsx
@@ -1,6 +1,8 @@
 import { NavLink, Outlet, useLocation, Navigate } from 'react-router-dom';
 import ConnectWalletButton from '../components/ConnectWalletButton';
 import React, { Suspense } from 'react';
+import { HiExternalLink } from 'react-icons/hi';
+import { psmHref, analyticsHref } from "../config";
 
 const NetworkDropdown = React.lazy(
   () => import('../components/NetworkDropdown'),
@@ -9,19 +11,25 @@ const NetworkDropdown = React.lazy(
 type NavItemProps = {
   label: string;
   href: string;
+  isExternal?: boolean;
 };
 
-const NavItem = ({ label, href }: NavItemProps) => {
+const NavItem = ({ label, href, isExternal = false }: NavItemProps) => {
   return (
     <li>
       <NavLink
         className="h-full justify-between flex flex-col font-serif"
         to={href}
+        target={isExternal ? '_blank' : ''}
       >
         {({ isActive }) => (
           <>
             <div className="h-1.5"></div>
-            <span className="m-2 font-bold">{label}</span>
+              <span className="inline-flex items-center">
+                  <span className="m-2 font-bold">{label}</span>
+                  {isExternal && <HiExternalLink />}
+              </span>
+
             <div
               className={
                 isActive
@@ -61,6 +69,8 @@ const Root = () => {
           <nav>
             <ul className="h-24 flex flex-row space-x-12">
               <NavItem label="Vaults" href="/vaults" />
+              <NavItem label="PSM" href={psmHref} isExternal={true}/>
+              <NavItem label="Analytics" href={analyticsHref} isExternal={true}/>
             </ul>
           </nav>
         </div>


### PR DESCRIPTION
Closes: #148 #157

## Problem
Cross dapp connection needed to be improved

## Work Done
Added two external links to navigate the user to `PSM` and `Analytics` pages that use the below links respectively
* https://psm.inter.trade/
* https://info.inter.trade/

### Here's the final look

<img width="657" alt="Screen Shot 2023-09-15 at 11 35 46" src="https://github.com/Agoric/dapp-inter/assets/32987478/09c0f08a-5a17-4339-9226-f63c6d9b75d7">
