### PR TITLE
Node selector button

### DIFF
--- a/src/components/Combobox.tsx
+++ b/src/components/Combobox.tsx
@@ -1,5 +1,5 @@
 import { Combobox as HeadlessComboBox, Transition } from '@headlessui/react';
-import { Fragment } from 'react';
+import { Fragment, useCallback, useState } from 'react';
 import { FiChevronDown } from 'react-icons/fi';
 
 const Combobox = ({
@@ -11,13 +11,34 @@ const Combobox = ({
   value?: string;
   onValueChange: (newValue: string) => void;
 }) => {
+  const [query, setQuery] = useState('');
+
+  const filteredOptions =
+    query === ''
+      ? options
+      : options?.filter(option => {
+          return option.includes(query);
+        });
+
+  const onInputChange = useCallback(
+    (newValue: string) => {
+      setQuery(newValue);
+    },
+    [setQuery],
+  );
+
+  const optionClasses = ({ active }: { active: boolean }) =>
+    `relative cursor-pointer select-none py-2 pl-4 pr-4 text-gray-900 hover:bg-gray-100 ${
+      active && 'bg-black bg-opacity-5'
+    }`;
+
   return (
     <HeadlessComboBox value={value ?? ''} onChange={onValueChange}>
       <div className="relative mt-1">
         <div className="relative w-full cursor-default overflow-hidden rounded-lg border-solid border-[#d8d8d8] border-[1px] text-left">
           <HeadlessComboBox.Input
             className="w-full border-none py-2 pl-3 pr-10 text-sm leading-5 text-gray-900 focus:ring-0 focus-visible:outline-none"
-            onChange={event => onValueChange(event.target.value)}
+            onChange={event => onInputChange(event.target.value)}
           />
           {options && (
             <HeadlessComboBox.Button className="absolute inset-y-0 right-0 flex items-center pr-2">
@@ -36,15 +57,23 @@ const Combobox = ({
             leaveTo="opacity-0"
           >
             <HeadlessComboBox.Options className="z-50 absolute mt-1 max-h-60 w-full overflow-auto rounded-md bg-white py-1 text-base shadow-lg ring-1 ring-black/5 focus:outline-none sm:text-sm">
-              {options?.map(option => (
+              {filteredOptions?.map(option => (
                 <HeadlessComboBox.Option
                   key={option}
                   value={option}
-                  className="relative cursor-pointer select-none py-2 pl-4 pr-4 text-gray-900 hover:bg-gray-100"
+                  className={optionClasses}
                 >
                   {option}
                 </HeadlessComboBox.Option>
               ))}
+              {query && !options?.includes(query) && (
+                <HeadlessComboBox.Option
+                  value={query}
+                  className={optionClasses}
+                >
+                  Add &quot;{query}&quot;
+                </HeadlessComboBox.Option>
+              )}
             </HeadlessComboBox.Options>
           </Transition>
         )}

--- a/src/components/Combobox.tsx
+++ b/src/components/Combobox.tsx
@@ -7,7 +7,7 @@ const Combobox = ({
   value,
   onValueChange,
 }: {
-  options?: string[];
+  options: string[];
   value?: string;
   onValueChange: (newValue: string) => void;
 }) => {
@@ -16,7 +16,7 @@ const Combobox = ({
   const filteredOptions =
     query === ''
       ? options
-      : options?.filter(option => {
+      : options.filter(option => {
           return option.includes(query);
         });
 
@@ -40,43 +40,36 @@ const Combobox = ({
             className="w-full border-none py-2 pl-3 pr-10 text-sm leading-5 text-gray-900 focus:ring-0 focus-visible:outline-none"
             onChange={event => onInputChange(event.target.value)}
           />
-          {options && (
-            <HeadlessComboBox.Button className="absolute inset-y-0 right-0 flex items-center pr-2">
-              <FiChevronDown
-                className="h-5 w-5 text-gray-400"
-                aria-hidden="true"
-              />
-            </HeadlessComboBox.Button>
-          )}
+          <HeadlessComboBox.Button className="absolute inset-y-0 right-0 flex items-center pr-2">
+            <FiChevronDown
+              className="h-5 w-5 text-gray-400"
+              aria-hidden="true"
+            />
+          </HeadlessComboBox.Button>
         </div>
-        {options && (
-          <Transition
-            as={Fragment}
-            leave="transition ease-in duration-100"
-            leaveFrom="opacity-100"
-            leaveTo="opacity-0"
-          >
-            <HeadlessComboBox.Options className="z-50 absolute mt-1 max-h-60 w-full overflow-auto rounded-md bg-white py-1 text-base shadow-lg ring-1 ring-black/5 focus:outline-none sm:text-sm">
-              {filteredOptions?.map(option => (
-                <HeadlessComboBox.Option
-                  key={option}
-                  value={option}
-                  className={optionClasses}
-                >
-                  {option}
-                </HeadlessComboBox.Option>
-              ))}
-              {query && !options?.includes(query) && (
-                <HeadlessComboBox.Option
-                  value={query}
-                  className={optionClasses}
-                >
-                  Add &quot;{query}&quot;
-                </HeadlessComboBox.Option>
-              )}
-            </HeadlessComboBox.Options>
-          </Transition>
-        )}
+        <Transition
+          as={Fragment}
+          leave="transition ease-in duration-100"
+          leaveFrom="opacity-100"
+          leaveTo="opacity-0"
+        >
+          <HeadlessComboBox.Options className="z-50 absolute mt-1 max-h-60 w-full overflow-auto rounded-md bg-white py-1 text-base shadow-lg ring-1 ring-black/5 focus:outline-none sm:text-sm">
+            {filteredOptions?.map(option => (
+              <HeadlessComboBox.Option
+                key={option}
+                value={option}
+                className={optionClasses}
+              >
+                {option}
+              </HeadlessComboBox.Option>
+            ))}
+            {query && !options.includes(query) && (
+              <HeadlessComboBox.Option value={query} className={optionClasses}>
+                Add &quot;{query}&quot;
+              </HeadlessComboBox.Option>
+            )}
+          </HeadlessComboBox.Options>
+        </Transition>
       </div>
     </HeadlessComboBox>
   );

--- a/src/components/NodeSelectorDialog.tsx
+++ b/src/components/NodeSelectorDialog.tsx
@@ -9,7 +9,7 @@ import {
 import { useAtom, useAtomValue, useSetAtom } from 'jotai';
 import ActionsDialog from './ActionsDialog';
 import Combobox from 'components/Combobox';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { fetchAllAddrs } from 'utils/rpc';
 
 const useRpcAddrs = () => {

--- a/src/components/SettingsButton.tsx
+++ b/src/components/SettingsButton.tsx
@@ -1,0 +1,24 @@
+import { useSetAtom } from 'jotai';
+import { useCallback } from 'react';
+import { HiOutlineCog } from 'react-icons/hi';
+import { isNodeSelectorOpenAtom } from 'store/app';
+
+const SettingsButton = () => {
+  const setIsNodeSelectorOpen = useSetAtom(isNodeSelectorOpenAtom);
+
+  const onClick = useCallback(() => {
+    setIsNodeSelectorOpen(true);
+  }, [setIsNodeSelectorOpen]);
+
+  return (
+    <button
+      aria-label="Settings"
+      className="inline-flex justify-center items-center rounded-full bg-black bg-opacity-5 px-2 py-2 text-2xl hover:bg-opacity-10 active:bg-opacity-20 focus:outline-none focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-opacity-75 transition"
+      onClick={onClick}
+    >
+      <HiOutlineCog />
+    </button>
+  );
+};
+
+export default SettingsButton;

--- a/src/views/Root.tsx
+++ b/src/views/Root.tsx
@@ -3,6 +3,7 @@ import ConnectWalletButton from '../components/ConnectWalletButton';
 import React, { Suspense } from 'react';
 import { HiExternalLink } from 'react-icons/hi';
 import { psmHref, analyticsHref } from '../config';
+import SettingsButton from 'components/SettingsButton';
 
 const NetworkDropdown = React.lazy(
   () => import('../components/NetworkDropdown'),
@@ -79,6 +80,7 @@ const Root = () => {
           </nav>
         </div>
         <div className="flex flex-row space-x-2 items-center mr-6 m-2">
+          <SettingsButton />
           {networkDropdown}
           <ConnectWalletButton />
         </div>


### PR DESCRIPTION
fixes https://github.com/Agoric/dapp-inter/issues/211

Also improved a11y of node selector dialog by making it work with keyboard users. Before, if you wanted to add a custom node, you had to type it then click out of the input box to select it. If you pressed tab or enter, it would revert the custom input.

## Screenshots

![image](https://github.com/Agoric/dapp-inter/assets/8848650/c19703d0-2cfa-4f35-9749-306571340433)

![image](https://github.com/Agoric/dapp-inter/assets/8848650/ee8a0ea8-e51e-4d34-9402-18b9ea3a874b)
