### PR TITLE
feat: show liquidation price in vault summary

### DIFF
--- a/src/components/AdjustVaultSummary.tsx
+++ b/src/components/AdjustVaultSummary.tsx
@@ -244,9 +244,9 @@ const AdjustVaultSummary = () => {
                       : 'N/A'
                   }
                   right={
-                    newCollateralizationRatio
+                    newCollateralizationRatio && vaultIsAdjusted
                       ? displayPercent(newCollateralizationRatio, 0) + '%'
-                      : 'N/A'
+                      : '---'
                   }
                 />
                 <TableRowWithArrow

--- a/src/components/NewVaultOfferSummary.tsx
+++ b/src/components/NewVaultOfferSummary.tsx
@@ -22,6 +22,7 @@ import { debtAfterChange } from 'utils/vaultMath';
 import { DebtAction } from 'store/adjustVault';
 import { HiOutlineInformationCircle } from 'react-icons/hi';
 import { Popover, Transition } from '@headlessui/react';
+import { ceilMultiplyBy } from '@agoric/zoe/src/contractSupport';
 
 type TableRowProps = {
   left: string;
@@ -57,7 +58,7 @@ const NewVaultOfferSummary = () => {
   const [isProvisionDialogOpen, setIsProvisionDialogOpen] = useState(false);
   const isSmartWalletStatusLoading = isSmartWalletProvisioned === null;
 
-  const { displayAmount, displayBrandPetname, displayPercent } =
+  const { displayAmount, displayBrandPetname, displayPercent, displayPrice } =
     useAtomValue(displayFunctionsAtom) ?? {};
 
   const { metrics, params, factoryParams, userVaults } = useVaultStore(
@@ -96,6 +97,25 @@ const NewVaultOfferSummary = () => {
 
   const mintAmount =
     valueToReceive && debtBrand && AmountMath.make(debtBrand, valueToReceive);
+
+  const maximumLockedPriceForLiquidation =
+    depositAmount &&
+    mintAmount &&
+    selectedParams &&
+    !AmountMath.isEmpty(depositAmount)
+      ? {
+          amountIn: depositAmount,
+          amountOut: ceilMultiplyBy(
+            mintAmount,
+            selectedParams.liquidationMargin,
+          ),
+        }
+      : undefined;
+
+  const maximumLockedPriceForLiquidationForDisplay =
+    maximumLockedPriceForLiquidation
+      ? displayPrice && displayPrice(maximumLockedPriceForLiquidation, 2)
+      : '---';
 
   const mintAmountForDisplay =
     displayAmount && displayBrandPetname && mintAmount
@@ -265,6 +285,10 @@ const NewVaultOfferSummary = () => {
                 />
                 <TableRow left="Stability Fee" right={stabilityFeeForDisplay} />
                 <TableRow left="Minting Fee" right={creationFeeForDisplay} />
+                <TableRow
+                  left="Liquidation Price"
+                  right={maximumLockedPriceForLiquidationForDisplay}
+                />
               </tbody>
             </table>
           </div>

--- a/src/components/NewVaultOfferSummary.tsx
+++ b/src/components/NewVaultOfferSummary.tsx
@@ -268,6 +268,10 @@ const NewVaultOfferSummary = () => {
                   left="Collateralization Ratio"
                   right={collateralizationRatioForDisplay}
                 />
+                <TableRow
+                  left="Liquidation Price"
+                  right={maximumLockedPriceForLiquidationForDisplay}
+                />
               </tbody>
             </table>
           </div>
@@ -285,10 +289,6 @@ const NewVaultOfferSummary = () => {
                 />
                 <TableRow left="Stability Fee" right={stabilityFeeForDisplay} />
                 <TableRow left="Minting Fee" right={creationFeeForDisplay} />
-                <TableRow
-                  left="Liquidation Price"
-                  right={maximumLockedPriceForLiquidationForDisplay}
-                />
               </tbody>
             </table>
           </div>


### PR DESCRIPTION
See #223 


### Adjust Vault Summary
<img width="434" alt="Screenshot 2024-01-19 at 6 29 11 PM" src="https://github.com/Agoric/dapp-inter/assets/11021913/4c27f32d-dee0-44f7-a477-d323af105fc9">

## New Vault Summary

<img width="397" alt="Screenshot 2024-01-19 at 6 53 55 PM" src="https://github.com/Agoric/dapp-inter/assets/11021913/4c7fde57-33af-408f-8abf-edf3c1d89bbf">


### Adjust Vault Collateralization Ratio ([9ec4568](https://github.com/Agoric/dapp-inter/commit/9ec45685156b10f886e2d8781debeb090b68d938))

Added a small fix since Collateralization Ratio always appeared to be "changed". Here's the before:
<img width="449" alt="Screenshot 2024-01-19 at 6 54 27 PM" src="https://github.com/Agoric/dapp-inter/assets/11021913/1b58e3e4-1f3d-4cee-bc27-a1735e518aca">
