### PR TITLE
feat: make collateral cards same size

### DIFF
--- a/src/components/CollateralChoice.tsx
+++ b/src/components/CollateralChoice.tsx
@@ -18,7 +18,7 @@ const TableRow = ({ left, right }: TableTowParams) => {
 };
 
 const cardClasses = clsx(
-  'w-fit px-6 pt-2 pb-4 bg-white rounded-10',
+  'w-64 px-6 pt-2 pb-4 bg-white rounded-10',
   'shadow-card box-border',
   'outline-2 outline-offset-2 border-2',
 );
@@ -91,7 +91,7 @@ const CollateralChoice = ({ id, displayFunctions }: CollateralChoiceParams) => {
       <div
         className={clsx(
           cardClasses,
-          'h-[248px] w-60 border-transparent text-lg text-alert pt-3',
+          'h-[248px] border-transparent text-lg text-alert pt-3',
         )}
       >
         <p>Error: {error && error.toString()}</p>
@@ -103,7 +103,7 @@ const CollateralChoice = ({ id, displayFunctions }: CollateralChoiceParams) => {
     return <SkeletonCollateralChoice />;
   }
   const {
-    displayAmount,
+    displayAbbreviatedAmount,
     displayBrandPetname,
     displayPercent,
     displayBrandIcon,
@@ -128,7 +128,7 @@ const CollateralChoice = ({ id, displayFunctions }: CollateralChoiceParams) => {
   };
 
   // This for all intents and purposes has the role of a button, even though
-  // its conntent doesn't fit the content categories of a button:
+  // its content doesn't fit the content categories of a button:
   // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#technical_summary
   //
   // Perhaps the cards that you click to select are an a11y anti-pattern, could
@@ -137,9 +137,8 @@ const CollateralChoice = ({ id, displayFunctions }: CollateralChoiceParams) => {
     <button
       onClick={onClick}
       className={clsx(
-        'w-fit px-6 pt-2 pb-4 bg-white rounded-10 cursor-pointer',
-        'shadow-card box-border',
-        'outline-2 outline-offset-2 border-2 hover:scale-105 transition',
+        cardClasses,
+        'cursor-pointer hover:scale-105 transition',
         isSelected ? 'border-interGreen' : 'border-transparent',
       )}
     >
@@ -153,7 +152,7 @@ const CollateralChoice = ({ id, displayFunctions }: CollateralChoiceParams) => {
       <h3 className="text-center text-xl font-medium font-serif normal-case">
         {collateralTitle}
       </h3>
-      <table className="mt-4">
+      <table className="mt-4 w-full">
         <tbody>
           <TableRow
             left="Min. Collat. Ratio"
@@ -168,10 +167,8 @@ const CollateralChoice = ({ id, displayFunctions }: CollateralChoiceParams) => {
           />
           <TableRow
             left="IST Available"
-            right={`${displayAmount(
+            right={`${displayAbbreviatedAmount(
               mintedAvailable,
-              0,
-              'locale',
             )} ${displayBrandPetname(params.debtLimit.brand)}`}
           />
           <TableRow

--- a/src/components/CreateVault.tsx
+++ b/src/components/CreateVault.tsx
@@ -38,7 +38,12 @@ const CreateVault = () => {
                 />
               ))
             ) : (
-              <SkeletonCollateralChoice />
+              <>
+                <SkeletonCollateralChoice />
+                <SkeletonCollateralChoice />
+                <SkeletonCollateralChoice />
+                <SkeletonCollateralChoice />
+              </>
             )}
           </div>
           <ConfigureNewVault />

--- a/src/components/ProvisionSmartWalletNoticeDialog.tsx
+++ b/src/components/ProvisionSmartWalletNoticeDialog.tsx
@@ -46,7 +46,7 @@ const ProvisionSmartWalletNoticeDialog = ({
   onClose,
 }: Props) => {
   const rpc = useAtomValue(rpcNodeAtom);
-  const { smartWalletFee, error: smartWalletFeeError } =
+  const { smartWalletFee, error: _smartWalletFeeError } =
     useSmartWalletFeeQuery(rpc);
 
   const smartWalletFeeForDisplay = smartWalletFee

--- a/src/store/app.ts
+++ b/src/store/app.ts
@@ -14,7 +14,6 @@ import { makeWalletService } from 'service/wallet';
 import { secondsSinceEpoch } from 'utils/date';
 import { makeAgoricChainStorageWatcher } from '@agoric/rpc';
 import { makeAgoricWalletConnection } from '@agoric/web-components';
-import type { Id as ToastId } from 'react-toastify';
 import type { DisplayInfo, Brand, AssetKind } from '@agoric/ertp/src/types';
 import type { PursesJSONState } from '@agoric/wallet-backend';
 

--- a/src/utils/displayFunctions.ts
+++ b/src/utils/displayFunctions.ts
@@ -62,6 +62,19 @@ export const makeDisplayFunctions = (brandToInfo: Map<Brand, BrandInfo>) => {
     return stringifyRatio(ratio, getDecimalPlaces, placesToShow);
   };
 
+  const displayAbbreviatedAmount = (
+    amount: Amount,
+  ) => {
+    const decimalPlaces = getDecimalPlaces(amount.brand);
+    const parsed = stringifyValue(amount.value, AssetKind.NAT, decimalPlaces);
+
+    return new Intl.NumberFormat(navigator.language, {
+      notation: "compact",
+      compactDisplay: "short",
+      maximumFractionDigits: 2,
+    }).format(Number(parsed));
+  }
+
   const displayAmount = (
     amount: Amount,
     placesToShow?: number,
@@ -124,6 +137,7 @@ export const makeDisplayFunctions = (brandToInfo: Map<Brand, BrandInfo>) => {
     displayPercent,
     displayBrandPetname,
     displayRatio,
+    displayAbbreviatedAmount,
     displayAmount,
     getDecimalPlaces,
     displayBrandIcon,

--- a/src/utils/displayFunctions.ts
+++ b/src/utils/displayFunctions.ts
@@ -62,18 +62,16 @@ export const makeDisplayFunctions = (brandToInfo: Map<Brand, BrandInfo>) => {
     return stringifyRatio(ratio, getDecimalPlaces, placesToShow);
   };
 
-  const displayAbbreviatedAmount = (
-    amount: Amount,
-  ) => {
+  const displayAbbreviatedAmount = (amount: Amount) => {
     const decimalPlaces = getDecimalPlaces(amount.brand);
     const parsed = stringifyValue(amount.value, AssetKind.NAT, decimalPlaces);
 
     return new Intl.NumberFormat(navigator.language, {
-      notation: "compact",
-      compactDisplay: "short",
+      notation: 'compact',
+      compactDisplay: 'short',
       maximumFractionDigits: 2,
     }).format(Number(parsed));
-  }
+  };
 
   const displayAmount = (
     amount: Amount,


### PR DESCRIPTION
fixes https://github.com/Agoric/dapp-inter/issues/236

## Description
Fixes the vault cards to 256x248px, uses a new `displayAbbreviatedAmount` utility that shows at most 5 significant figures to prevent overflow, also shows 4 skeleton loading collateral choices by default to decrease layout thrashing when loading.

## Screenshots
<img width="596" alt="Screenshot 2024-02-15 at 10 41 49 PM" src="https://github.com/Agoric/dapp-inter/assets/8848650/f01f1d18-e03f-467a-916d-69692449d916">
