### PR TITLE
chore: suggest connection with chain before connecting with wallet

### DIFF
--- a/src/components/ConnectWalletButton.tsx
+++ b/src/components/ConnectWalletButton.tsx
@@ -10,6 +10,7 @@ import {
   networkConfigAtom,
   walletServiceAtom,
 } from 'store/app';
+import { suggestChain } from '@agoric/web-components';
 import clsx from 'clsx';
 import { useEffect } from 'react';
 import { useStore } from 'zustand';
@@ -53,6 +54,11 @@ const ConnectWalletButton = () => {
     return 'Connect Wallet';
   })();
 
+  const handleSuggestChainAndConnectWallet = async () => {
+    await suggestChain(url);
+    walletService.connect();
+  };
+
   const isDisabled = !chainStorageWatcher;
 
   return (
@@ -64,7 +70,7 @@ const ConnectWalletButton = () => {
           ? 'hover:bg-black hover:bg-opacity-5 cursor-pointer'
           : 'cursor-default',
       )}
-      onClick={() => walletService.connect()}
+      onClick={handleSuggestChainAndConnectWallet}
     >
       <>
         {status}


### PR DESCRIPTION
Issue:
I've encountered an error after installing a new Keplr extension and visiting the dapp-inter URL. When attempting to connect with the wallet, I receive the following error:
![image](https://github.com/Agoric/dapp-inter/assets/60459172/dd76a4aa-f5c7-4b7c-a552-746d0e15a56b)

This happens because when I imported or created my wallet, I didn't select the Agoric Chain. Also, there weren't any options available to select any testing chains:
![A](https://github.com/Agoric/dapp-inter/assets/60459172/0b38207f-5a37-4f02-a0fa-67967d656fd0)

I noticed that new users may have trouble connecting to the wallet. Typically, we can connect without any problems, but it seems that if we're already connected to the testing chains, it's easier. For example, when I was using the `offerup` dapp initially and then switched to `dapp-inter`, connecting my wallet was smooth because I was already connected to the Agoric chain during my work with `offerup` dapp.

What I've observed is that new users might face difficulty in connecting with the wallet and get the error message I shared above. 

So, to fix this, I've utilized the `suggestChain` utility from `@agoric/web-components`. Now, whenever we switch between testing networks, it prompts us to connect with the chain first if we're not already connected. I implemented this for the offerup dapp.

NOTE: This issue only occurs in our local environment; the production version works perfectly fine.