### PR TITLE
ci: add daliy scheduled run for emerynet testing

### DIFF
--- a/.github/workflows/reusable-workflow.yml
+++ b/.github/workflows/reusable-workflow.yml
@@ -12,6 +12,9 @@ jobs:
   e2e:
     runs-on: ubuntu-latest
 
+    env:
+      IS_EMERYNET_TEST: ${{ github.event_name == 'schedule' || inputs.network == 'emerynet' }}
+
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -33,6 +36,10 @@ jobs:
       - name: Run e2e tests
         run: ${{ inputs.docker_compose_command }}
         env:
+          # conditionals based on github event
+          SYNPRESS_PROFILE: ${{ env.IS_EMERYNET_TEST == 'true' && 'daily-tests' || 'synpress' }}
+          CYPRESS_AGORIC_NET: ${{ env.IS_EMERYNET_TEST == 'true' && 'emerynet' || 'local' }}
+          # for docker-compose.yml
           COMPOSE_DOCKER_CLI_BUILD: 1
           DOCKER_BUILDKIT: 1
           DOCKER_DEFAULT_PLATFORM: linux/amd64

--- a/.github/workflows/vaults.yml
+++ b/.github/workflows/vaults.yml
@@ -5,6 +5,8 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  schedule:
+    - cron: '0 0 * * *'
 
 concurrency:
   group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label ||
@@ -17,5 +19,5 @@ jobs:
     with:
       docker_compose_command: |
         docker-compose -f test/e2e/docker-compose-vaults.yml \
-        --profile synpress up --build \
+        --profile $SYNPRESS_PROFILE up --build \
         --exit-code-from synpress

--- a/test/e2e/.eslintrc.cjs
+++ b/test/e2e/.eslintrc.cjs
@@ -3,4 +3,7 @@ const synpressPath = path.join(process.cwd(), '/node_modules/@agoric/synpress');
 
 module.exports = {
   extends: `${synpressPath}/.eslintrc.js`,
+  rules: {
+    'testing-library/await-async-queries': 0,
+  },
 };

--- a/test/e2e/docker-compose-base.yml
+++ b/test/e2e/docker-compose-base.yml
@@ -4,6 +4,7 @@ services:
   synpress:
     profiles:
       - synpress
+      - daily-tests
     container_name: synpress
     build: ../..
     environment:
@@ -34,6 +35,8 @@ services:
       - GITHUB_REF=${GITHUB_REF}
       - GITHUB_BASE_REF=${GITHUB_BASE_REF}
       - GITHUB_HEAD_REF=${GITHUB_HEAD_REF}
+      # Variables for dapp-psm
+      - CYPRESS_AGORIC_NET=${CYPRESS_AGORIC_NET}
       - SECRET_WORDS="orbit bench unit task food shock brand bracket domain regular warfare company announce wheel grape trust sphere boy doctor half guard ritual three ecology"
     entrypoint: []
     working_dir: /app
@@ -44,6 +47,7 @@ services:
   display:
     profiles:
       - synpress
+      - daily-tests
     container_name: display
     image: synthetixio/display:016121eafdfff448414894d0ca5a50b1d72b62eb-base
     environment:
@@ -68,6 +72,7 @@ services:
   video:
     profiles:
       - synpress
+      - daily-tests
     container_name: video
     image: synthetixio/video:457bb48776c3b14de232d9dda620ba9188dc40ac-base
     volumes:

--- a/test/e2e/docker-compose-vaults.yml
+++ b/test/e2e/docker-compose-vaults.yml
@@ -7,13 +7,12 @@ services:
     depends_on:
       - display
       - video
-      - agd
     command: >
       bash -c 'echo -n "======> local noVNC URL: http://localhost:8080/vnc.html?autoconnect=true " &&
       yarn wait-on http://display:8080 &&
       echo -n "======> remote noVNC URL: " &&
       curl -s ngrok:4040/api/tunnels | jq -r .tunnels[0].public_url &&
-      nginx &&
+      if [ "$CYPRESS_AGORIC_NET" == "local" ]; then nginx; fi &&
       npx start-server-and-test "yarn dev" http-get://localhost:5173 "yarn test:e2e --spec test/e2e/specs/test.spec.js"'
     networks:
       - x12

--- a/test/e2e/specs/test.spec.js
+++ b/test/e2e/specs/test.spec.js
@@ -47,6 +47,10 @@ describe('Vaults UI Test Cases', () => {
           'You can manage your vaults from the "My Vaults" view.',
         ).should('exist');
       });
+      cy.get('label.cursor-pointer input[type="checkbox"]').check();
+      cy.contains('Proceed').click();
+
+      cy.acceptAccess();
     });
 
     it('should adjust the collateral by performing a withdrawl and approve the transaction successfully', () => {
@@ -64,6 +68,85 @@ describe('Vaults UI Test Cases', () => {
             .within(() => {
               cy.get('input[type="number"]').click();
               cy.get('input[type="number"]').type(5);
+            });
+        });
+
+      cy.contains('button', 'Adjust Vault').click();
+      cy.confirmTransaction().then(taskCompleted => {
+        expect(taskCompleted).to.be.true;
+        cy.contains('p', "Your vault's balances have been updated.").should(
+          'exist',
+        );
+        cy.contains('Back to my vaults').click();
+      });
+    });
+
+    it('should create a new vault and approve the transaction successfully', () => {
+      cy.visit('/');
+
+      cy.contains('button', 'Add new vault').click();
+      cy.contains('button', /ATOM/).click();
+
+      cy.contains('.input-label', 'ATOM to lock up *')
+        .next()
+        .within(() => {
+          cy.get('input[type="number"]').click();
+          cy.get('input[type="number"]').clear();
+          cy.get('input[type="number"]').type(2);
+        });
+
+      cy.contains('button', 'Create Vault').click();
+
+      cy.confirmTransaction().then(taskCompleted => {
+        expect(taskCompleted).to.be.true;
+        cy.contains(
+          'p',
+          'You can manage your vaults from the "My Vaults" view.',
+        ).should('exist');
+      });
+    });
+
+    it('should open the new vault', () => {
+      cy.visit('/');
+      cy.get('span')
+        .contains(/My Vaults.*\(\d+\)/)
+        .children()
+        .first()
+        .spread((...element) => {
+          // Get the total number of vaults present
+          const vaultCount = Number(element[0].innerHTML.slice(2, -1));
+
+          cy.get('div.shadow-card div.text-secondary:contains("#")')
+            .should('have.length', vaultCount)
+            .spread((...vaults) => {
+              // Get the vault with the largest number and click on it
+              const maxValue = vaults.reduce(
+                (maxValue, currentValueRaw) => {
+                  const currentValue = Number(
+                    currentValueRaw.innerHTML.slice(1),
+                  );
+                  return currentValue > maxValue ? currentValue : maxValue;
+                },
+                Number(vaults[0].innerHTML.slice(1)),
+              );
+              cy.get(
+                `div.shadow-card div.text-secondary:contains("#${maxValue}")`,
+              ).click();
+            });
+        });
+    });
+
+    it('should adjust the collateral by performing a withdrawl and approve the transaction successfully', () => {
+      cy.contains('div', 'Adjust Collateral')
+        .next('.grid-cols-2')
+        .within(() => {
+          cy.contains('button', /^(Deposit|Withdraw|No Action)$/).click();
+          cy.contains('button', 'Withdraw').click();
+          cy.contains('.input-label', 'Amount')
+            .next('.input-wrapper')
+            .within(() => {
+              cy.get('input[type="number"]').click();
+              cy.get('input[type="number"]').type(1);
             });
         });
 
@@ -151,9 +234,6 @@ describe('Vaults UI Test Cases', () => {
     });
 
     it('should close the vault and approve the transaction successfully', () => {
-      cy.visit('/');
-      cy.contains('div', /ATOM.*#8/).click();
-
       cy.contains('Close Out Vault').click();
       cy.contains('button.bg-interPurple', 'Close Out Vault').click();
 

--- a/test/e2e/specs/test.spec.js
+++ b/test/e2e/specs/test.spec.js
@@ -79,9 +79,6 @@ describe('Vaults UI Test Cases', () => {
       if (!networkPhrases.isLocal)
         cy.get('button').contains('Keep using Old Version').click();
 
-      if (networkPhrases.isLocal)
-        cy.contains('button', 'Add new vault').click();
-
       cy.contains('button', /ATOM/).click();
 
       cy.contains('ATOM to lock up *')

--- a/test/e2e/specs/test.spec.js
+++ b/test/e2e/specs/test.spec.js
@@ -12,13 +12,63 @@ describe('Vaults UI Test Cases', () => {
       },
     };
     const networkPhrases = phrasesList[Cypress.env('AGORIC_NET') || 'local'];
+
+    it('should setup the wallet', () => {
+      if (networkPhrases.isLocal) {
+        cy.setupWallet();
+      } else {
+        const walletAddress = {
+          value: null,
+        };
+        cy.setupWallet({
+          createNewWallet: true,
+          walletName: 'my created wallet',
+        });
+        cy.origin('https://wallet.agoric.app/', () => {
+          cy.visit('/wallet/');
+
+          cy.get('input.PrivateSwitchBase-input').click();
+          cy.contains('Proceed').click();
+        });
+        cy.acceptAccess();
+
+        cy.origin('https://wallet.agoric.app/', () => {
+          cy.visit('/wallet/');
+
+          cy.contains(/agoric.{39}/).spread(element => {
+            return element.innerHTML.match(/agoric.{39}/)[0];
+          });
+        }).then(address => {
+          walletAddress.value = address;
+        });
+        cy.origin(
+          'https://emerynet.faucet.agoric.net',
+          { args: { walletAddress } },
+          ({ walletAddress }) => {
+            cy.visit('/');
+            cy.get('[id="address"]').first().type(walletAddress.value);
+            cy.get('[type="submit"]').first().click();
+            cy.get('body').contains('success').should('exist');
+
+            cy.visit('/');
+            cy.get('[id="address"]').first().type(walletAddress.value);
+            cy.get('[type="radio"][value="client"]').click();
+            cy.get('[type="submit"]').first().click();
+            cy.get('body').contains('success').should('exist');
+          },
+        );
+      }
+    });
+
     it('should connect with the wallet', () => {
       cy.visit('/');
 
-      cy.get('button').contains('Local Network').click();
-      cy.get('button').contains(networkPhrases.interNetwork).click();
-      if (!networkPhrases.isLocal)
+      if (!networkPhrases.isLocal) {
+        cy.contains('button', 'Dismiss').click();
+        cy.get('button').contains('Local Network').click();
+        cy.get('button').contains(networkPhrases.interNetwork).click();
         cy.get('button').contains('Keep using Old Version').click();
+      }
 
       cy.contains('Connect Wallet').click();
       cy.acceptAccess().then(taskCompleted => {
@@ -34,6 +84,9 @@ describe('Vaults UI Test Cases', () => {
 
     it('should create a new vault and approve the transaction successfully', () => {
       cy.visit('/');
+      if (!networkPhrases.isLocal)
+        cy.get('button').contains('Keep using Old Version').click();
+
       cy.contains('button', /ATOM/).click();
 
       cy.contains('ATOM to lock up *')
@@ -93,7 +146,8 @@ describe('Vaults UI Test Cases', () => {
       if (!networkPhrases.isLocal)
         cy.get('button').contains('Keep using Old Version').click();
 
-      cy.contains('button', 'Add new vault').click();
+      if (networkPhrases.isLocal)
+        cy.contains('button', 'Add new vault').click();
       cy.contains('button', /ATOM/).click();
 
       cy.contains('.input-label', 'ATOM to lock up *')

--- a/test/e2e/specs/test.spec.js
+++ b/test/e2e/specs/test.spec.js
@@ -89,7 +89,7 @@ describe('Vaults UI Test Cases', () => {
         .within(() => {
           cy.get('input[type="number"]').click();
           cy.get('input[type="number"]').clear();
-          cy.get('input[type="number"]').type(10); // 2 in local
+          cy.get('input[type="number"]').type(10);
         });
 
       cy.contains('button', 'Create Vault').click();
@@ -139,7 +139,7 @@ describe('Vaults UI Test Cases', () => {
             .next('.input-wrapper')
             .within(() => {
               cy.get('input[type="number"]').click();
-              cy.get('input[type="number"]').type(1); // 5 in local
+              cy.get('input[type="number"]').type(1);
             });
         });
 

--- a/test/e2e/specs/test.spec.js
+++ b/test/e2e/specs/test.spec.js
@@ -1,18 +1,24 @@
 import { mnemonics } from '../test.utils';
 describe('Vaults UI Test Cases', () => {
   context('Test commands', () => {
-    it('should set up wallet', () => {
-      // Using exports from the synthetic-chain lib instead of hardcoding mnemonics UNTIL https://github.com/Agoric/agoric-3-proposals/issues/154
-      cy.setupWallet({
-        secretWords: mnemonics.user1,
-        walletName: 'user1',
-      }).then(taskCompleted => {
-        expect(taskCompleted).to.be.true;
-      });
-    });
-
+    const phrasesList = {
+      emerynet: {
+        interNetwork: 'Agoric Emerynet',
+        isLocal: false,
+      },
+      local: {
+        interNetwork: 'Local Network',
+        isLocal: true,
+      },
+    };
+    const networkPhrases = phrasesList[Cypress.env('AGORIC_NET') || 'local'];
     it('should connect with the wallet', () => {
       cy.visit('/');
+
+      cy.get('button').contains('Local Network').click();
+      cy.get('button').contains(networkPhrases.interNetwork).click();
+      if (!networkPhrases.isLocal)
+        cy.get('button').contains('Keep using Old Version').click();
 
       cy.contains('Connect Wallet').click();
       cy.acceptAccess().then(taskCompleted => {
@@ -58,31 +64,34 @@ describe('Vaults UI Test Cases', () => {
       cy.contains('button', 'Back to vaults').click();
       cy.contains('div', /ATOM.*#8/).click();
 
-      cy.contains('div', 'Adjust Collateral')
-        .next('.grid-cols-2')
-        .within(() => {
-          cy.contains('button', /^(Deposit|Withdraw|No Action)$/).click();
-          cy.contains('button', 'Withdraw').click();
-          cy.contains('.input-label', 'Amount')
-            .next('.input-wrapper')
-            .within(() => {
-              cy.get('input[type="number"]').click();
-              cy.get('input[type="number"]').type(5);
-            });
-        });
+        cy.contains('div', 'Adjust Collateral')
+          .next('.grid-cols-2')
+          .within(() => {
+            cy.contains('button', /^(Deposit|Withdraw|No Action)$/).click();
+            cy.contains('button', 'Withdraw').click();
+            cy.contains('.input-label', 'Amount')
+              .next('.input-wrapper')
+              .within(() => {
+                cy.get('input[type="number"]').click();
+                cy.get('input[type="number"]').type(5);
+              });
+          });
 
-      cy.contains('button', 'Adjust Vault').click();
-      cy.confirmTransaction().then(taskCompleted => {
-        expect(taskCompleted).to.be.true;
-        cy.contains('p', "Your vault's balances have been updated.").should(
-          'exist',
-        );
-        cy.contains('Back to my vaults').click();
-      });
+        cy.contains('button', 'Adjust Vault').click();
+        cy.confirmTransaction().then(taskCompleted => {
+          expect(taskCompleted).to.be.true;
+          cy.contains('p', "Your vault's balances have been updated.", {
+            timeout: 60000,
+          }).should('exist');
+          cy.contains('Back to my vaults').click();
+        });
+      }
     });
 
     it('should create a new vault and approve the transaction successfully', () => {
       cy.visit('/');
+      if (!networkPhrases.isLocal)
+        cy.get('button').contains('Keep using Old Version').click();
 
       cy.contains('button', 'Add new vault').click();
       cy.contains('button', /ATOM/).click();
@@ -102,12 +111,13 @@ describe('Vaults UI Test Cases', () => {
         cy.contains(
           'p',
           'You can manage your vaults from the "My Vaults" view.',
+          { timeout: 60000 },
         ).should('exist');
+        cy.contains('Manage my Vaults').click();
       });
     });
 
     it('should open the new vault', () => {
-      cy.visit('/');
       cy.get('span')
         .contains(/My Vaults.*\(\d+\)/)
         .children()
@@ -119,6 +129,9 @@ describe('Vaults UI Test Cases', () => {
           cy.get('div.shadow-card div.text-secondary:contains("#")')
             .should('have.length', vaultCount)
             .spread((...vaults) => {
+              expect(
+                vaults.filter(vaultNo => !/^#\d+$/.test(vaultNo.innerHTML)),
+              ).to.be.empty;
               // Get the vault with the largest number and click on it
               const maxValue = vaults.reduce(
                 (maxValue, currentValueRaw) => {
@@ -153,9 +166,9 @@ describe('Vaults UI Test Cases', () => {
       cy.contains('button', 'Adjust Vault').click();
       cy.confirmTransaction().then(taskCompleted => {
         expect(taskCompleted).to.be.true;
-        cy.contains('p', "Your vault's balances have been updated.").should(
-          'exist',
-        );
+        cy.contains('p', "Your vault's balances have been updated.", {
+          timeout: 60000,
+        }).should('exist');
         cy.contains('Adjust more').click();
       });
     });
@@ -178,9 +191,9 @@ describe('Vaults UI Test Cases', () => {
       cy.contains('button', 'Adjust Vault').click();
       cy.confirmTransaction().then(taskCompleted => {
         expect(taskCompleted).to.be.true;
-        cy.contains('p', "Your vault's balances have been updated.").should(
-          'exist',
-        );
+        cy.contains('p', "Your vault's balances have been updated.", {
+          timeout: 60000,
+        }).should('exist');
         cy.contains('Adjust more').click();
       });
     });
@@ -202,9 +215,9 @@ describe('Vaults UI Test Cases', () => {
       cy.contains('button', 'Adjust Vault').click();
       cy.confirmTransaction().then(taskCompleted => {
         expect(taskCompleted).to.be.true;
-        cy.contains('p', "Your vault's balances have been updated.").should(
-          'exist',
-        );
+        cy.contains('p', "Your vault's balances have been updated.", {
+          timeout: 60000,
+        }).should('exist');
         cy.contains('Adjust more').click();
       });
     });
@@ -226,9 +239,9 @@ describe('Vaults UI Test Cases', () => {
       cy.contains('button', 'Adjust Vault').click();
       cy.confirmTransaction().then(taskCompleted => {
         expect(taskCompleted).to.be.true;
-        cy.contains('p', "Your vault's balances have been updated.").should(
-          'exist',
-        );
+        cy.contains('p', "Your vault's balances have been updated.", {
+          timeout: 60000,
+        }).should('exist');
         cy.contains('Adjust more').click();
       });
     });

--- a/test/e2e/synpress.config.cjs
+++ b/test/e2e/synpress.config.cjs
@@ -9,4 +9,5 @@ module.exports = defineConfig({
     specPattern: 'test/e2e/specs/**/*spec.{js,jsx,ts,tsx}',
     supportFile: 'test/e2e/support.js',
   },
+  pageLoadTimeout: 60000,
 });

--- a/test/e2e/test.utils.js
+++ b/test/e2e/test.utils.js
@@ -13,3 +13,15 @@ export const accountAddresses = {
 
 export const LIQUIDATING_TIMEOUT = 20 * 60 * 1000;
 export const LIQUIDATED_TIMEOUT = 10 * 60 * 1000;
+export const MINUTE_MS = 60000;
+
+export const phrasesList = {
+  emerynet: {
+    interNetwork: 'Agoric Emerynet',
+    isLocal: false,
+  },
+  local: {
+    interNetwork: 'Local Network',
+    isLocal: true,
+  },
+};


### PR DESCRIPTION
This PR does the following:
- It adjusts the previously written tests to work for both local network and emerynet. these updates include
    - changing the order of test to make the transactions cyclic. i.e. the amount put into the vault is returned in the end
    - update the wallet creation flow to use previously created wallet on local but to create a brand new wallet on emerynet
- it adds a scheduled run of the e2e_tests github action to run once everyday on emerynet 

**Note:** the behaviour of provisioning ATOM and IST from https://emerynet.faucet.agoric.net seems to be unreliable and flaky, but at the moment I am not aware of any other way to get these tokens in a new account