### PR TITLE
chore: update ci for dapp-inter to run shell commands

### DIFF
--- a/test/e2e/docker-compose.yml
+++ b/test/e2e/docker-compose.yml
@@ -45,7 +45,12 @@ services:
       - ./docker/videos:/app/test/e2e/videos
       - ./docker/screenshots:/app/test/e2e/screenshots
     command: >
-      bash -c 'echo -n "======> local noVNC URL: http://localhost:8080/vnc.html?autoconnect=true " && pnpm wait-on http://display:8080 && echo -n "======> remote noVNC URL: " && curl -s ngrok:4040/api/tunnels | jq -r .tunnels[0].public_url && nginx && yarn test:e2e:ci'
+      bash -c 'echo -n "======> local noVNC URL: http://localhost:8080/vnc.html?autoconnect=true " &&
+      yarn wait-on http://display:8080 &&
+      echo -n "======> remote noVNC URL: " &&
+      curl -s ngrok:4040/api/tunnels | jq -r .tunnels[0].public_url &&
+      nginx &&
+      yarn test:e2e:ci'
     networks:
       - x11
 


### PR DESCRIPTION
The PR updates the base image from `synthetixio/docker-e2e` to `ghcr.io/agoric/agoric-sdk:latest` in order to support Agoric shell commands within the CI)environment. It includes necessary modifications to ensure the smooth functioning of the CI process with the new base image.