### PR TITLE
test: bash scripts for liquidation operations with vaults

### DIFF
--- a/test/e2e/test-scripts/common.sh
+++ b/test/e2e/test-scripts/common.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+# Common variables
+export mnemonicGov1="such field health riot cost kitten silly tube flash wrap festival portion imitate this make question host bitter puppy wait area glide soldier knee"
+export mnemonicGov2="physical immune cargo feel crawl style fox require inhale law local glory cheese bring swear royal spy buyer diesel field when task spin alley"
+export mnemonicUser1="tackle hen gap lady bike explain erode midnight marriage wide upset culture model select dial trial swim wood step scan intact what card symptom"
+export gov1AccountAddress=agoric1ee9hr0jyrxhy999y755mp862ljgycmwyp4pl7q
+export gov2AccountAddress=agoric1wrfh296eu2z34p6pah7q04jjuyj3mxu9v98277
+export user1Address=agoric1ydzxwh6f893jvpaslmaz6l8j2ulup9a7x8qvvq
+
+checkFieldValue() {
+  fieldValue=$(echo "$output" | jq -r ".$1")
+  if [ -z "$fieldValue" ]; then
+    echo "Error: $1 field is missing or empty"
+    exit 1
+  fi
+  
+  expectedValue="$2"
+  if [ "$fieldValue" != "$expectedValue" ]; then
+    echo "Error: $1 field does not match the expected value"
+    echo "Expected: $expectedValue"
+    echo "Actual: $fieldValue"
+    exit 1
+  fi
+}
+
+addKeys() {
+  commandToExecute="agd keys add $1 --recover --keyring-backend=test"
+  mnemonicPrompt="Enter your bip39 mnemonic"
+
+  output=$(expect -c "
+      spawn $commandToExecute
+      expect {
+          \"override\" {
+              send \"y\r\"
+              exp_continue
+          }
+          \"$mnemonicPrompt\" {
+              send \"$2\r\"
+              exp_continue
+          }
+      }
+      expect eof
+  ")
+
+  echo "$output"
+}
+
+addKeyAndCheck() {
+    keyName="$1"
+    mnemonic="$2"
+    expectedAddress="$3"
+
+    result=$(addKeys "$keyName" "$mnemonic")
+    if [[ $result == *"$expectedAddress"* ]]; then
+        echo "Keys for $keyName added successfully"
+    else
+        echo "Error: $result" >&2
+        exit 1
+    fi
+}

--- a/test/e2e/test-scripts/create-vaults.sh
+++ b/test/e2e/test-scripts/create-vaults.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+source ./test/e2e/test-scripts/common.sh
+
+if [ "$#" -lt 2 ] || [ "$#" -gt 3 ]; then
+    echo "Usage: $0 <wantMinted> <giveCollateral> [userType]"
+    exit 1
+fi
+
+wantMinted=$1
+giveCollateral=$2
+userType=${3:-user1}
+
+if [ "$userType" = "user1" ]; then
+    accountAddress="$user1Address"
+else
+    accountAddress="$gov1AccountAddress"
+fi
+
+echo "Creating Vault..."
+agops vaults open --wantMinted "$wantMinted" --giveCollateral "$giveCollateral" > /tmp/want-ist.json
+
+echo "Broadcasting..."
+agops perf satisfaction --executeOffer /tmp/want-ist.json --from "$accountAddress" --keyring-backend=test 2>&1
+wait

--- a/test/e2e/test-scripts/place-bids.sh
+++ b/test/e2e/test-scripts/place-bids.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+source ./test/e2e/test-scripts/common.sh
+
+placeBidByPrice() {
+    fromAddress=$1
+    giveAmount=$2
+    price=$3
+
+    echo "Placing bid by price..."
+    output=$(agops inter bid by-price --from  $fromAddress --give $giveAmount --price $price --keyring-backend=test)
+    wait
+
+    if echo "$output" | grep -q "Your bid has been accepted"; then
+    echo "Bid Placed Successfully"
+    echo "" >&2
+    else
+        echo "Error: $output" >&2
+        exit 1
+    fi
+}
+
+placeBidByDiscount() {
+    fromAddress=$1
+    giveAmount=$2
+    discount=$3
+
+    echo "Placing bid by discount..."
+    output=$(agops inter bid by-discount --from  $fromAddress --give $giveAmount --discount $discount --keyring-backend=test)
+    wait
+
+    if echo "$output" | grep -q "Your bid has been accepted"; then
+    echo "Bid Placed Successfully"
+    echo "" >&2
+    else
+        echo "Error: $output" >&2
+        exit 1
+    fi
+}
+
+
+placeBidByPrice $gov1AccountAddress 90IST 9
+placeBidByDiscount $gov1AccountAddress 80IST 10
+placeBidByDiscount $gov1AccountAddress 150IST 15

--- a/test/e2e/test-scripts/set-oracle-price.sh
+++ b/test/e2e/test-scripts/set-oracle-price.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+if [ "$#" -ne 1 ]; then
+    echo "Usage: $0 <price>"
+    exit 1
+fi
+
+source ./test/e2e/test-scripts/common.sh
+
+
+addKeyAndCheck "gov1" "$mnemonicGov1" "$gov1AccountAddress"
+addKeyAndCheck "gov2" "$mnemonicGov2" "$gov2AccountAddress"
+
+output=$(agops oracle setPrice --keys gov1,gov2 --pair ATOM.USD --price $1 --keyring-backend test)
+
+if [ $? -eq 0 ]; then
+    echo "Success: Price set to $1"
+    exit 0
+else
+    echo "Command failed"
+    echo "$output"
+    exit 1
+fi

--- a/test/e2e/test-scripts/view-auction.sh
+++ b/test/e2e/test-scripts/view-auction.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+source ./test/e2e/test-scripts/common.sh
+
+fieldName="$1"
+expectedValue="$2"
+
+output=$(agops inter auction status)
+checkFieldValue "$fieldName" "$expectedValue"
+echo "Field is present and expected value is matched"


### PR DESCRIPTION
The PR adds bash scripts for creating vaults, changing prices, placing bids, and viewing auctions. 

These scripts will be used in a subsequent PR for liquidation testing. 

To test these scripts locally, make sure your local chain is up and running. Run the following command:
```
docker run -d -p 26657:26657 -p 1317:1317 -p 9090:9090 ghcr.io/agoric/agoric-3-proposals:latest

```

Make sure you are present in the root directory of `dapp-inter`. You can test the scripts randomly with different values. 

- Testing creating vaults. To create a vault, run the script:
```
~/dapp-inter/test/e2e/test-scripts/create-vaults.sh 400 70 gov1 
```
This will create a vault that submits `70 ATOMs` as collateral and mints `400 ISTs` We will later use these ISTs to place bids. 

- Testing changing price. For example:
```
~/dapp-inter/test/e2e/test-scripts/set-oracle-price.sh 9.99
```
In this script, the parameter 9.99 represents the desired price value you want to update in the oracle. 

- Testing placing bids. Run the `place-bids.sh` script to place bids from the `gov1` account:
```
~/dapp-inter/test/e2e/test-scripts/place-bids.sh
```

- Testing auction. You can test presence of different auction fields and their values following this example:
```
~/dapp-inter/test/e2e/test-scripts/view-auction.sh "book0.collateralAvailable" "0 ATOM"
```

In this example, `book0.collateralAvailable` is the field we are looking for and `0 ATOM` is the expected value. 