### PR TITLE
ci: split docker compose and add reusable E2E workflow

### DIFF
--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -34,7 +34,7 @@ jobs:
             ${{ runner.os }}-buildx-
       - name: Run e2e tests
         run: |
-          docker-compose -f test/e2e/docker-compose.yml --profile synpress up --build --exit-code-from synpress
+          docker-compose -f test/e2e/docker-compose-vaults.yml --profile synpress up --build --exit-code-from synpress
         env:
           COMPOSE_DOCKER_CLI_BUILD: 1
           DOCKER_BUILDKIT: 1

--- a/.github/workflows/reusable-workflow.yml
+++ b/.github/workflows/reusable-workflow.yml
@@ -1,15 +1,12 @@
-name: E2E tests
+name: Reusable E2E Workflow
 
 on:
-  push:
-    branches: [main]
-  pull_request:
-    branches: [main]
-
-concurrency:
-  group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label ||
-    github.head_ref || github.ref }}'
-  cancel-in-progress: true
+  workflow_call:
+    inputs:
+      docker_compose_command:
+        description: 'Docker Compose command to run E2E tests'
+        required: true
+        type: string
 
 jobs:
   e2e:
@@ -32,9 +29,9 @@ jobs:
           key: ${{ runner.os }}-buildx-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-buildx-
+
       - name: Run e2e tests
-        run: |
-          docker-compose -f test/e2e/docker-compose-vaults.yml --profile synpress up --build --exit-code-from synpress
+        run: ${{ inputs.docker_compose_command }}
         env:
           COMPOSE_DOCKER_CLI_BUILD: 1
           DOCKER_BUILDKIT: 1
@@ -45,7 +42,6 @@ jobs:
           ANVIL_FORK_URL: ${{ secrets.ANVIL_FORK_URL }}
           GH_PAT: ${{ secrets.GH_PAT }}
           GH_USERNAME: ${{ secrets.GH_USERNAME }}
-          # cypress dashboard
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CYPRESS_PROJECT_ID: ${{ secrets.CYPRESS_PROJECT_ID }}
           CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}

--- a/.github/workflows/vaults.yml
+++ b/.github/workflows/vaults.yml
@@ -1,0 +1,21 @@
+name: Vaults E2E tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label ||
+    github.head_ref || github.ref }}'
+  cancel-in-progress: true
+
+jobs:
+  run-e2e:
+    uses: ./.github/workflows/reusable-workflow.yml
+    with:
+      docker_compose_command: |
+        docker-compose -f test/e2e/docker-compose-vaults.yml \
+        --profile synpress up --build \
+        --exit-code-from synpress

--- a/package.json
+++ b/package.json
@@ -12,8 +12,7 @@
     "test": "vitest",
     "coverage": "vitest run --coverage",
     "postinstall": "patch-package",
-    "test:e2e": "SKIP_EXTENSION_SETUP=true EXTENSION=keplr synpress run --configFile=test/e2e/synpress.config.cjs",
-    "test:e2e:ci": "start-server-and-test 'yarn dev' http-get://localhost:5173 'yarn test:e2e'"
+    "test:e2e": "SKIP_EXTENSION_SETUP=true EXTENSION=keplr synpress run --configFile=test/e2e/synpress.config.cjs"
   },
   "dependencies": {
     "@agoric/casting": "^0.4.3-u13.0",

--- a/test/e2e/docker-compose-base.yml
+++ b/test/e2e/docker-compose-base.yml
@@ -35,24 +35,11 @@ services:
       - GITHUB_BASE_REF=${GITHUB_BASE_REF}
       - GITHUB_HEAD_REF=${GITHUB_HEAD_REF}
       - SECRET_WORDS="orbit bench unit task food shock brand bracket domain regular warfare company announce wheel grape trust sphere boy doctor half guard ritual three ecology"
-    depends_on:
-      - display
-      - video
-      - agd
     entrypoint: []
     working_dir: /app
     volumes:
       - ./docker/videos:/app/test/e2e/videos
       - ./docker/screenshots:/app/test/e2e/screenshots
-    command: >
-      bash -c 'echo -n "======> local noVNC URL: http://localhost:8080/vnc.html?autoconnect=true " &&
-      yarn wait-on http://display:8080 &&
-      echo -n "======> remote noVNC URL: " &&
-      curl -s ngrok:4040/api/tunnels | jq -r .tunnels[0].public_url &&
-      nginx &&
-      yarn test:e2e:ci'
-    networks:
-      - x11
 
   display:
     profiles:
@@ -65,8 +52,6 @@ services:
       - DISPLAY_HEIGHT=1080
     ports:
       - '8080:8080'
-    networks:
-      - x11
 
   ngrok:
     profiles:
@@ -79,10 +64,6 @@ services:
     environment:
       - NGROK_AUTH=${NGROK_AUTH}
       - NGROK_BASIC_AUTH=${NGROK_BASIC_AUTH}
-    depends_on:
-      - display
-    networks:
-      - x11
 
   video:
     profiles:
@@ -95,10 +76,6 @@ services:
       - FILE_NAME=CI-full-video.mp4
       - SE_SCREEN_WIDTH=1920
       - SE_SCREEN_HEIGHT=1080
-    depends_on:
-      - display
-    networks:
-      - x11
 
   agd:
     profiles:
@@ -115,8 +92,3 @@ services:
     environment:
       DEST: 1
       DEBUG: 'SwingSet:ls,SwingSet:vat'
-    networks:
-      - x11
-
-networks:
-  x11:

--- a/test/e2e/docker-compose-vaults.yml
+++ b/test/e2e/docker-compose-vaults.yml
@@ -1,0 +1,54 @@
+version: '3.9'
+services:
+  synpress:
+    extends:
+      file: docker-compose-base.yml
+      service: synpress
+    depends_on:
+      - display
+      - video
+      - agd
+    command: >
+      bash -c 'echo -n "======> local noVNC URL: http://localhost:8080/vnc.html?autoconnect=true " &&
+      yarn wait-on http://display:8080 &&
+      echo -n "======> remote noVNC URL: " &&
+      curl -s ngrok:4040/api/tunnels | jq -r .tunnels[0].public_url &&
+      nginx &&
+      npx start-server-and-test "yarn dev" http-get://localhost:5173 "yarn test:e2e --spec test/e2e/specs/test.spec.js"'
+    networks:
+      - x12
+
+  display:
+    extends:
+      file: docker-compose-base.yml
+      service: display
+    networks:
+      - x12
+
+  ngrok:
+    extends:
+      file: docker-compose-base.yml
+      service: ngrok
+    depends_on:
+      - display
+    networks:
+      - x12
+
+  video:
+    extends:
+      file: docker-compose-base.yml
+      service: video
+    depends_on:
+      - display
+    networks:
+      - x12
+
+  agd:
+    extends:
+      file: docker-compose-base.yml
+      service: agd
+    networks:
+      - x12
+
+networks:
+  x12:


### PR DESCRIPTION
## Changes
- Split the docker-compose file into shared(`docker-compose-base.yml`) and specific(`docker-compose-vaults.yml`) configurations.
- Added a reusable workflow for end-to-end (E2E) tests.

## Motivation
While working on Liquidation tests in PR #268, I noticed that the CI process takes too long because we were running both Vaults and Liquidation test cases in a single GitHub Actions runner. To optimize our CI workflow, this PR enables parallel GitHub Action runners for running Vaults and Liquidation(when #268 is merged) E2E tests separately. This can save us time and simplify the management of our tests and CI workflows.

I've already implemented these changes in PR #268, but I want to keep that PR focused and prevent it from becoming too large. Once this PR is merged, I can rebase PR #268 accordingly.