### PR TITLE
refactor: simplify cypress command for adding keys from shell

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ENV PATH="/usr/src/agoric-sdk/packages/agoric-cli/bin:${PATH}"
 
 # Install necessary dependencies
 RUN apt-get update \
-    && apt-get install -y wget gnupg ca-certificates jq expect xvfb
+    && apt-get install -y wget gnupg ca-certificates jq xvfb
 
 # Install Chrome
 RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \

--- a/test/e2e/support.js
+++ b/test/e2e/support.js
@@ -3,22 +3,7 @@ import { accountAddresses } from './test.utils';
 
 Cypress.Commands.add('addKeys', params => {
   const { keyName, mnemonic, expectedAddress } = params;
-  const command = `
-    expect -c "
-      spawn agd keys add ${keyName} --recover --keyring-backend=test
-      expect {
-          \\"override\\" {
-              send \\"y\\r\\"
-              exp_continue
-          }
-          \\"Enter your bip39 mnemonic\\" {
-              send \\"${mnemonic}\\r\\"
-              exp_continue
-          }
-      }
-      expect eof
-    "
-  `;
+  const command = `echo ${mnemonic} | agd keys add ${keyName} --recover --keyring-backend=test`;
 
   cy.exec(command).then(({ stdout }) => {
     expect(stdout).to.contain(expectedAddress);


### PR DESCRIPTION
The PR does the following:
- Simplifies the cypress custom command for adding keys from the shell. 
- Remove installing `expect` package in the `Dockerfile`. This package was previously used with `agd keys add` command. 