### PR TITLE
test: liquidate vaults and viewing auction data

### DIFF
--- a/test/e2e/specs/liquidation.spec.js
+++ b/test/e2e/specs/liquidation.spec.js
@@ -1,4 +1,9 @@
-import { mnemonics, accountAddresses } from '../test.utils';
+import {
+  mnemonics,
+  accountAddresses,
+  LIQUIDATING_TIMEOUT,
+  LIQUIDATED_TIMEOUT,
+} from '../test.utils';
 
 describe('Wallet App Test Cases', () => {
   context('Setting up accounts', () => {
@@ -123,6 +128,56 @@ describe('Wallet App Test Cases', () => {
       cy.contains(
         /Please increase your collateral or repay your outstanding IST debt./,
       );
+    });
+
+    it('should wait and verify vaults are being liquidated', () => {
+      cy.contains(/3 vaults are liquidating./, {
+        timeout: LIQUIDATING_TIMEOUT,
+      });
+    });
+
+    it('should verify the value of startPrice from the CLI successfully', () => {
+      const propertyName = 'book0.startPrice';
+      const expectedValue = '9.99 IST/ATOM';
+
+      cy.verifyAuctionData(propertyName, expectedValue);
+    });
+
+    it('should verify the value of startProceedsGoal from the CLI successfully', () => {
+      const propertyName = 'book0.startProceedsGoal';
+      const expectedValue = '309.54 IST';
+
+      cy.verifyAuctionData(propertyName, expectedValue);
+    });
+
+    it('should verify the value of startCollateral from the CLI successfully', () => {
+      const propertyName = 'book0.startCollateral';
+      const expectedValue = '45 ATOM';
+
+      cy.verifyAuctionData(propertyName, expectedValue);
+    });
+
+    it('should verify the value of collateralAvailable from the CLI successfully', () => {
+      const propertyName = 'book0.collateralAvailable';
+      const expectedValue = '45 ATOM';
+
+      cy.verifyAuctionData(propertyName, expectedValue);
+    });
+
+    // Tests ran fine locally but failed in CI. Updating a3p container replicated failure locally. Tests pass with older container version.
+    // UNTIL: a3p container compatibility is resolved.
+    it.skip('should wait and verify vaults are liquidated', () => {
+      cy.contains(/Collateral left to claim/, { timeout: LIQUIDATED_TIMEOUT });
+      cy.contains(/3.42 ATOM/);
+      cy.contains(/3.07 ATOM/);
+      cy.contains(/2.84 ATOM/);
+    });
+
+    it.skip('should verify the value of collateralAvailable from the CLI successfully', () => {
+      const propertyName = 'book0.collateralAvailable';
+      const expectedValue = '9.659301 ATOM';
+
+      cy.verifyAuctionData(propertyName, expectedValue);
     });
   });
 });

--- a/test/e2e/support.js
+++ b/test/e2e/support.js
@@ -56,3 +56,20 @@ Cypress.Commands.add('placeBidByDiscount', params => {
     expect(stdout).to.contain('Your bid has been accepted');
   });
 });
+
+Cypress.Commands.add('verifyAuctionData', (propertyName, expectedValue) => {
+  return cy
+    .exec(`agops inter auction status`, {
+      failOnNonZeroExit: false,
+    })
+    .then(({ stdout }) => {
+      const output = JSON.parse(stdout);
+      const propertyValue = Cypress._.get(output, propertyName);
+
+      if (!propertyValue) {
+        throw new Error(`Error: ${propertyName} property is missing or empty`);
+      }
+
+      expect(propertyValue).to.equal(expectedValue);
+    });
+});

--- a/test/e2e/test.utils.js
+++ b/test/e2e/test.utils.js
@@ -10,3 +10,6 @@ export const accountAddresses = {
   gov1: 'agoric1ee9hr0jyrxhy999y755mp862ljgycmwyp4pl7q',
   gov2: 'agoric1wrfh296eu2z34p6pah7q04jjuyj3mxu9v98277',
 };
+
+export const LIQUIDATING_TIMEOUT = 20 * 60 * 1000;
+export const LIQUIDATED_TIMEOUT = 10 * 60 * 1000;


### PR DESCRIPTION
The PR adds tests to ensure vaults are in a `liquidating` state and verifies the auction data. 

It also adds tests for verifying if a vault has reached a `liquidated` state but I'm currently deferring the execution of these tests in CI after updating the a3p Docker container, as I've noticed a discrepancy in behavior.