### PR TITLE
ci: add scheduled runs of liquidation tests

### DIFF
--- a/.github/workflows/liquidation-reconstitution.yml
+++ b/.github/workflows/liquidation-reconstitution.yml
@@ -1,10 +1,8 @@
 name: Liquidation Reconstitution E2E tests
 
 on:
-  push:
-    branches: [main]
-  pull_request:
-    branches: [main]
+  schedule:
+    - cron: '0 0 * * *'
 
 concurrency:
   group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label ||

--- a/.github/workflows/liquidation.yml
+++ b/.github/workflows/liquidation.yml
@@ -1,10 +1,8 @@
 name: Liquidation E2E tests
 
 on:
-  push:
-    branches: [main]
-  pull_request:
-    branches: [main]
+  schedule:
+    - cron: '0 0 * * *'
 
 concurrency:
   group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label ||


### PR DESCRIPTION
Due to the lengthy execution time of 20 to 25 minutes for liquidation tests on the local chain, the PR excludes these tests from PR executions. Instead, we will schedule regular runs of these tests.