### PR TITLE
tests: add tests for setting up governance params

### DIFF
--- a/test/e2e/specs/liquidation-reconstitution.spec.js
+++ b/test/e2e/specs/liquidation-reconstitution.spec.js
@@ -5,6 +5,7 @@ import {
   LIQUIDATING_TIMEOUT,
   LIQUIDATED_TIMEOUT,
   econGovURL,
+  MINUTE_MS,
 } from '../test.utils';
 
 describe('Wallet App Test Cases', () => {
@@ -130,7 +131,7 @@ describe('Wallet App Test Cases', () => {
     });
 
     it('should wait for proposal to pass', () => {
-      cy.wait(60000 - Date.now() + startTime);
+      cy.wait(MINUTE_MS - Date.now() + startTime);
       cy.visit(econGovURL);
 
       cy.get('button').contains('History').click();
@@ -228,7 +229,7 @@ describe('Wallet App Test Cases', () => {
     });
 
     it('should wait for proposal to pass', () => {
-      cy.wait(60000 - Date.now() + startTime);
+      cy.wait(MINUTE_MS - Date.now() + startTime);
       cy.visit(econGovURL);
 
       cy.get('button').contains('History').click();

--- a/test/e2e/specs/liquidation-reconstitution.spec.js
+++ b/test/e2e/specs/liquidation-reconstitution.spec.js
@@ -10,6 +10,12 @@ describe('Wallet App Test Cases', () => {
     // Using exports from the synthetic-chain lib instead of hardcoding mnemonics UNTIL https://github.com/Agoric/agoric-3-proposals/issues/154
     it('should set up wallets', () => {
       cy.setupWallet({
+        secretWords: mnemonics.user1,
+        walletName: 'user1',
+      }).then(taskCompleted => {
+        expect(taskCompleted).to.be.true;
+      });
+      cy.setupWallet({
         secretWords: mnemonics.gov1,
         walletName: 'gov1',
       }).then(taskCompleted => {
@@ -21,17 +27,210 @@ describe('Wallet App Test Cases', () => {
       }).then(taskCompleted => {
         expect(taskCompleted).to.be.true;
       });
-      cy.setupWallet({
-        secretWords: mnemonics.user1,
-        walletName: 'user1',
-      }).then(taskCompleted => {
-        expect(taskCompleted).to.be.true;
-      });
+    });
+  });
+
+  context('Adjusting manager params from econ-gov', () => {
+    it('should connect with chain and wallet', () => {
+      cy.visit('https://econ-gov.inter.trade/?agoricNet=local');
+      cy.acceptAccess();
+    });
+    it('should allow gov2 to create a proposal', () => {
+      cy.visit('https://econ-gov.inter.trade/?agoricNet=local');
+      cy.acceptAccess();
+
+      cy.get('button').contains('Vaults').click();
+      cy.get('button').contains('Select Manager').click();
+      cy.get('button').contains('manager0').click();
+
+      cy.get('label')
+        .contains('LiquidationMargin')
+        .parent()
+        .within(() => {
+          cy.get('input').clear().type('150');
+        });
+
+      cy.get('label')
+        .contains('LiquidationPadding')
+        .parent()
+        .within(() => {
+          cy.get('input').clear().type('25');
+        });
+
+      cy.get('label')
+        .contains('LiquidationPenalty')
+        .parent()
+        .within(() => {
+          cy.get('input').clear().type('1');
+        });
+
+      cy.get('label')
+        .contains('StabilityFee')
+        .parent()
+        .within(() => {
+          cy.get('input').clear().type('1');
+        });
+
+      cy.get('label')
+        .contains('MintFee')
+        .parent()
+        .within(() => {
+          cy.get('input').clear().type('0.5');
+        });
+
+      cy.get('label')
+        .contains('Minutes until close of vote')
+        .parent()
+        .within(() => {
+          cy.get('input').clear().type(1);
+        });
+      cy.get('[value="Propose Parameter Change"]').click();
+
+      cy.confirmTransaction();
+      cy.get('p')
+        .contains('sent')
+        .should('be.visible')
+        .then(() => {
+          startTime = Date.now();
+        });
+    });
+
+    it('should allow gov2 to vote on the proposal', () => {
+      cy.visit('https://econ-gov.inter.trade/?agoricNet=local');
+
+      cy.get('button').contains('Vote').click();
+      cy.get('p').contains('YES').click();
+      cy.get('input:enabled[value="Submit Vote"]').click();
+
+      cy.confirmTransaction();
+      cy.get('p').contains('sent').should('be.visible');
+    });
+
+    it('should allow gov1 to vote on the proposal', () => {
+      cy.switchWallet('gov1');
+      cy.visit('https://econ-gov.inter.trade/?agoricNet=local');
+
+      cy.get('button').contains('Vote').click();
+      cy.get('p').contains('YES').click();
+      cy.get('input:enabled[value="Submit Vote"]').click();
+
+      cy.confirmTransaction();
+      cy.get('p').contains('sent').should('be.visible');
+    });
+
+    it('should wait for proposal to pass', () => {
+      cy.wait(60000 - Date.now() + startTime);
+      cy.visit('https://econ-gov.inter.trade/?agoricNet=local');
+
+      cy.get('button').contains('History').click();
+
+      cy.get('code')
+        .contains('VaultFactory - ATOM')
+        .parent()
+        .parent()
+        .parent()
+        .within(() => {
+          cy.get('span').contains('Change Accepted').should('be.visible');
+        });
+    });
+  });
+
+  context('Adjusting auction params from econ-gov', () => {
+    it('should allow gov1 to create a proposal', () => {
+      cy.visit('https://econ-gov.inter.trade/?agoricNet=local');
+
+      cy.get('button').contains('Vaults').click();
+      cy.get('button').contains('Change Manager Params').click();
+      cy.get('button').contains('Change Auctioneer Params').click();
+
+      cy.get('label')
+        .contains('StartingRate')
+        .parent()
+        .within(() => {
+          cy.get('input').clear().type('10500');
+        });
+
+      cy.get('label')
+        .contains('LowestRate')
+        .parent()
+        .within(() => {
+          cy.get('input').clear().type('6500');
+        });
+
+      cy.get('label')
+        .contains('DiscountStep')
+        .parent()
+        .within(() => {
+          cy.get('input').clear().type('500');
+        });
+
+      cy.get('label')
+        .contains('AuctionStartDelay')
+        .parent()
+        .within(() => {
+          cy.get('input').clear().type('2');
+        });
+
+      cy.get('label')
+        .contains('Minutes until close of vote')
+        .parent()
+        .within(() => {
+          cy.get('input').clear().type(1);
+        });
+      cy.get('[value="Propose Parameter Change"]').click();
+
+      cy.confirmTransaction();
+      cy.get('p')
+        .contains('sent')
+        .should('be.visible')
+        .then(() => {
+          startTime = Date.now();
+        });
+    });
+
+    it('should allow gov1 to vote on the proposal', () => {
+      cy.visit('https://econ-gov.inter.trade/?agoricNet=local');
+
+      cy.get('button').contains('Vote').click();
+      cy.get('p').contains('YES').click();
+      cy.get('input:enabled[value="Submit Vote"]').click();
+
+      cy.confirmTransaction();
+      cy.get('p').contains('sent').should('be.visible');
+    });
+
+    it('should allow gov2 to vote on the proposal', () => {
+      cy.switchWallet('gov2');
+      cy.visit('https://econ-gov.inter.trade/?agoricNet=local');
+
+      cy.get('button').contains('Vote').click();
+      cy.get('p').contains('YES').click();
+      cy.get('input:enabled[value="Submit Vote"]').click();
+
+      cy.confirmTransaction();
+      cy.get('p').contains('sent').should('be.visible');
+    });
+
+    it('should wait for proposal to pass', () => {
+      cy.wait(60000 - Date.now() + startTime);
+      cy.visit('https://econ-gov.inter.trade/?agoricNet=local');
+
+      cy.get('button').contains('History').click();
+
+      cy.get('code')
+        .contains('VaultFactory - ATOM')
+        .parent()
+        .parent()
+        .parent()
+        .within(() => {
+          cy.get('span').contains('Change Accepted').should('be.visible');
+        });
     });
   });
 
   context('Creating vaults and changing ATOM price', () => {
     it('should connect with the wallet', () => {
+      cy.switchWallet('user1');
       cy.visit('/');
 
       cy.contains('Connect Wallet').click();

--- a/test/e2e/specs/liquidation-reconstitution.spec.js
+++ b/test/e2e/specs/liquidation-reconstitution.spec.js
@@ -1,11 +1,14 @@
+/* eslint-disable ui-testing/no-css-page-layout-selector */
 import {
   mnemonics,
   accountAddresses,
   LIQUIDATING_TIMEOUT,
   LIQUIDATED_TIMEOUT,
+  econGovURL,
 } from '../test.utils';
 
 describe('Wallet App Test Cases', () => {
+  let startTime;
   context('Setting up accounts', () => {
     // Using exports from the synthetic-chain lib instead of hardcoding mnemonics UNTIL https://github.com/Agoric/agoric-3-proposals/issues/154
     it('should set up wallets', () => {
@@ -32,11 +35,13 @@ describe('Wallet App Test Cases', () => {
 
   context('Adjusting manager params from econ-gov', () => {
     it('should connect with chain and wallet', () => {
-      cy.visit('https://econ-gov.inter.trade/?agoricNet=local');
-      cy.acceptAccess();
+      cy.visit(econGovURL);
+      cy.acceptAccess().then(taskCompleted => {
+        expect(taskCompleted).to.be.true;
+      });
     });
     it('should allow gov2 to create a proposal', () => {
-      cy.visit('https://econ-gov.inter.trade/?agoricNet=local');
+      cy.visit(econGovURL);
       cy.acceptAccess();
 
       cy.get('button').contains('Vaults').click();
@@ -47,42 +52,48 @@ describe('Wallet App Test Cases', () => {
         .contains('LiquidationMargin')
         .parent()
         .within(() => {
-          cy.get('input').clear().type('150');
+          cy.get('input').clear();
+          cy.get('input').type('150');
         });
 
       cy.get('label')
         .contains('LiquidationPadding')
         .parent()
         .within(() => {
-          cy.get('input').clear().type('25');
+          cy.get('input').clear();
+          cy.get('input').type('25');
         });
 
       cy.get('label')
         .contains('LiquidationPenalty')
         .parent()
         .within(() => {
-          cy.get('input').clear().type('1');
+          cy.get('input').clear();
+          cy.get('input').type('1');
         });
 
       cy.get('label')
         .contains('StabilityFee')
         .parent()
         .within(() => {
-          cy.get('input').clear().type('1');
+          cy.get('input').clear();
+          cy.get('input').type('1');
         });
 
       cy.get('label')
         .contains('MintFee')
         .parent()
         .within(() => {
-          cy.get('input').clear().type('0.5');
+          cy.get('input').clear();
+          cy.get('input').type('0.5');
         });
 
       cy.get('label')
         .contains('Minutes until close of vote')
         .parent()
         .within(() => {
-          cy.get('input').clear().type(1);
+          cy.get('input').clear();
+          cy.get('input').type(1);
         });
       cy.get('[value="Propose Parameter Change"]').click();
 
@@ -96,7 +107,7 @@ describe('Wallet App Test Cases', () => {
     });
 
     it('should allow gov2 to vote on the proposal', () => {
-      cy.visit('https://econ-gov.inter.trade/?agoricNet=local');
+      cy.visit(econGovURL);
 
       cy.get('button').contains('Vote').click();
       cy.get('p').contains('YES').click();
@@ -108,7 +119,7 @@ describe('Wallet App Test Cases', () => {
 
     it('should allow gov1 to vote on the proposal', () => {
       cy.switchWallet('gov1');
-      cy.visit('https://econ-gov.inter.trade/?agoricNet=local');
+      cy.visit(econGovURL);
 
       cy.get('button').contains('Vote').click();
       cy.get('p').contains('YES').click();
@@ -120,7 +131,7 @@ describe('Wallet App Test Cases', () => {
 
     it('should wait for proposal to pass', () => {
       cy.wait(60000 - Date.now() + startTime);
-      cy.visit('https://econ-gov.inter.trade/?agoricNet=local');
+      cy.visit(econGovURL);
 
       cy.get('button').contains('History').click();
 
@@ -137,7 +148,7 @@ describe('Wallet App Test Cases', () => {
 
   context('Adjusting auction params from econ-gov', () => {
     it('should allow gov1 to create a proposal', () => {
-      cy.visit('https://econ-gov.inter.trade/?agoricNet=local');
+      cy.visit(econGovURL);
 
       cy.get('button').contains('Vaults').click();
       cy.get('button').contains('Change Manager Params').click();
@@ -147,35 +158,40 @@ describe('Wallet App Test Cases', () => {
         .contains('StartingRate')
         .parent()
         .within(() => {
-          cy.get('input').clear().type('10500');
+          cy.get('input').clear();
+          cy.get('input').type('10500');
         });
 
       cy.get('label')
         .contains('LowestRate')
         .parent()
         .within(() => {
-          cy.get('input').clear().type('6500');
+          cy.get('input').clear();
+          cy.get('input').type('6500');
         });
 
       cy.get('label')
         .contains('DiscountStep')
         .parent()
         .within(() => {
-          cy.get('input').clear().type('500');
+          cy.get('input').clear();
+          cy.get('input').type('500');
         });
 
       cy.get('label')
         .contains('AuctionStartDelay')
         .parent()
         .within(() => {
-          cy.get('input').clear().type('2');
+          cy.get('input').clear();
+          cy.get('input').type('2');
         });
 
       cy.get('label')
         .contains('Minutes until close of vote')
         .parent()
         .within(() => {
-          cy.get('input').clear().type(1);
+          cy.get('input').clear();
+          cy.get('input').type(1);
         });
       cy.get('[value="Propose Parameter Change"]').click();
 
@@ -189,7 +205,7 @@ describe('Wallet App Test Cases', () => {
     });
 
     it('should allow gov1 to vote on the proposal', () => {
-      cy.visit('https://econ-gov.inter.trade/?agoricNet=local');
+      cy.visit(econGovURL);
 
       cy.get('button').contains('Vote').click();
       cy.get('p').contains('YES').click();
@@ -201,7 +217,7 @@ describe('Wallet App Test Cases', () => {
 
     it('should allow gov2 to vote on the proposal', () => {
       cy.switchWallet('gov2');
-      cy.visit('https://econ-gov.inter.trade/?agoricNet=local');
+      cy.visit(econGovURL);
 
       cy.get('button').contains('Vote').click();
       cy.get('p').contains('YES').click();
@@ -213,7 +229,7 @@ describe('Wallet App Test Cases', () => {
 
     it('should wait for proposal to pass', () => {
       cy.wait(60000 - Date.now() + startTime);
-      cy.visit('https://econ-gov.inter.trade/?agoricNet=local');
+      cy.visit(econGovURL);
 
       cy.get('button').contains('History').click();
 
@@ -225,18 +241,15 @@ describe('Wallet App Test Cases', () => {
         .within(() => {
           cy.get('span').contains('Change Accepted').should('be.visible');
         });
+
+      cy.switchWallet('user1');
     });
   });
 
   context('Creating vaults and changing ATOM price', () => {
     it('should connect with the wallet', () => {
-      cy.switchWallet('user1');
       cy.visit('/');
-
       cy.contains('Connect Wallet').click();
-      cy.acceptAccess().then(taskCompleted => {
-        expect(taskCompleted).to.be.true;
-      });
 
       cy.contains(
         'By clicking here you are indicating that you have read and agree to our',
@@ -249,7 +262,12 @@ describe('Wallet App Test Cases', () => {
       cy.acceptAccess().then(taskCompleted => {
         expect(taskCompleted).to.be.true;
       });
+
+      cy.acceptAccess().then(taskCompleted => {
+        expect(taskCompleted).to.be.true;
+      });
     });
+
     it('should set ATOM price to 12.34', () => {
       cy.addKeys({
         keyName: 'gov1',

--- a/test/e2e/specs/liquidation.spec.js
+++ b/test/e2e/specs/liquidation.spec.js
@@ -1,8 +1,10 @@
+/* eslint-disable ui-testing/no-css-page-layout-selector */
 import {
   mnemonics,
   accountAddresses,
   LIQUIDATING_TIMEOUT,
   LIQUIDATED_TIMEOUT,
+  econGovURL,
 } from '../test.utils';
 
 describe('Wallet App Test Cases', () => {
@@ -34,11 +36,13 @@ describe('Wallet App Test Cases', () => {
 
   context('Adjusting manager params from econ-gov', () => {
     it('should connect with chain and wallet', () => {
-      cy.visit('https://econ-gov.inter.trade/?agoricNet=local');
-      cy.acceptAccess();
+      cy.visit(econGovURL);
+      cy.acceptAccess().then(taskCompleted => {
+        expect(taskCompleted).to.be.true;
+      });
     });
     it('should allow gov2 to create a proposal', () => {
-      cy.visit('https://econ-gov.inter.trade/?agoricNet=local');
+      cy.visit(econGovURL);
       cy.acceptAccess();
 
       cy.get('button').contains('Vaults').click();
@@ -49,42 +53,48 @@ describe('Wallet App Test Cases', () => {
         .contains('LiquidationMargin')
         .parent()
         .within(() => {
-          cy.get('input').clear().type('150');
+          cy.get('input').clear();
+          cy.get('input').type('150');
         });
 
       cy.get('label')
         .contains('LiquidationPadding')
         .parent()
         .within(() => {
-          cy.get('input').clear().type('25');
+          cy.get('input').clear();
+          cy.get('input').type('25');
         });
 
       cy.get('label')
         .contains('LiquidationPenalty')
         .parent()
         .within(() => {
-          cy.get('input').clear().type('1');
+          cy.get('input').clear();
+          cy.get('input').type('1');
         });
 
       cy.get('label')
         .contains('StabilityFee')
         .parent()
         .within(() => {
-          cy.get('input').clear().type('1');
+          cy.get('input').clear();
+          cy.get('input').type('1');
         });
 
       cy.get('label')
         .contains('MintFee')
         .parent()
         .within(() => {
-          cy.get('input').clear().type('0.5');
+          cy.get('input').clear();
+          cy.get('input').type('0.5');
         });
 
       cy.get('label')
         .contains('Minutes until close of vote')
         .parent()
         .within(() => {
-          cy.get('input').clear().type(1);
+          cy.get('input').clear();
+          cy.get('input').type(1);
         });
       cy.get('[value="Propose Parameter Change"]').click();
 
@@ -98,7 +108,7 @@ describe('Wallet App Test Cases', () => {
     });
 
     it('should allow gov2 to vote on the proposal', () => {
-      cy.visit('https://econ-gov.inter.trade/?agoricNet=local');
+      cy.visit(econGovURL);
 
       cy.get('button').contains('Vote').click();
       cy.get('p').contains('YES').click();
@@ -110,7 +120,7 @@ describe('Wallet App Test Cases', () => {
 
     it('should allow gov1 to vote on the proposal', () => {
       cy.switchWallet('gov1');
-      cy.visit('https://econ-gov.inter.trade/?agoricNet=local');
+      cy.visit(econGovURL);
 
       cy.get('button').contains('Vote').click();
       cy.get('p').contains('YES').click();
@@ -122,7 +132,7 @@ describe('Wallet App Test Cases', () => {
 
     it('should wait for proposal to pass', () => {
       cy.wait(60000 - Date.now() + startTime);
-      cy.visit('https://econ-gov.inter.trade/?agoricNet=local');
+      cy.visit(econGovURL);
 
       cy.get('button').contains('History').click();
 
@@ -139,7 +149,7 @@ describe('Wallet App Test Cases', () => {
 
   context('Adjusting auction params from econ-gov', () => {
     it('should allow gov1 to create a proposal', () => {
-      cy.visit('https://econ-gov.inter.trade/?agoricNet=local');
+      cy.visit(econGovURL);
 
       cy.get('button').contains('Vaults').click();
       cy.get('button').contains('Change Manager Params').click();
@@ -149,35 +159,40 @@ describe('Wallet App Test Cases', () => {
         .contains('StartingRate')
         .parent()
         .within(() => {
-          cy.get('input').clear().type('10500');
+          cy.get('input').clear();
+          cy.get('input').type('10500');
         });
 
       cy.get('label')
         .contains('LowestRate')
         .parent()
         .within(() => {
-          cy.get('input').clear().type('6500');
+          cy.get('input').clear();
+          cy.get('input').type('6500');
         });
 
       cy.get('label')
         .contains('DiscountStep')
         .parent()
         .within(() => {
-          cy.get('input').clear().type('500');
+          cy.get('input').clear();
+          cy.get('input').type('500');
         });
 
       cy.get('label')
         .contains('AuctionStartDelay')
         .parent()
         .within(() => {
-          cy.get('input').clear().type('2');
+          cy.get('input').clear();
+          cy.get('input').type('2');
         });
 
       cy.get('label')
         .contains('Minutes until close of vote')
         .parent()
         .within(() => {
-          cy.get('input').clear().type(1);
+          cy.get('input').clear();
+          cy.get('input').type(1);
         });
       cy.get('[value="Propose Parameter Change"]').click();
 
@@ -191,7 +206,7 @@ describe('Wallet App Test Cases', () => {
     });
 
     it('should allow gov1 to vote on the proposal', () => {
-      cy.visit('https://econ-gov.inter.trade/?agoricNet=local');
+      cy.visit(econGovURL);
 
       cy.get('button').contains('Vote').click();
       cy.get('p').contains('YES').click();
@@ -203,7 +218,7 @@ describe('Wallet App Test Cases', () => {
 
     it('should allow gov2 to vote on the proposal', () => {
       cy.switchWallet('gov2');
-      cy.visit('https://econ-gov.inter.trade/?agoricNet=local');
+      cy.visit(econGovURL);
 
       cy.get('button').contains('Vote').click();
       cy.get('p').contains('YES').click();
@@ -215,7 +230,7 @@ describe('Wallet App Test Cases', () => {
 
     it('should wait for proposal to pass', () => {
       cy.wait(60000 - Date.now() + startTime);
-      cy.visit('https://econ-gov.inter.trade/?agoricNet=local');
+      cy.visit(econGovURL);
 
       cy.get('button').contains('History').click();
 
@@ -227,18 +242,15 @@ describe('Wallet App Test Cases', () => {
         .within(() => {
           cy.get('span').contains('Change Accepted').should('be.visible');
         });
+
+      cy.switchWallet('user1');
     });
   });
 
   context('Creating vaults and changing ATOM price', () => {
     it('should connect with the wallet', () => {
-      cy.switchWallet('user1');
       cy.visit('/');
-
       cy.contains('Connect Wallet').click();
-      cy.acceptAccess().then(taskCompleted => {
-        expect(taskCompleted).to.be.true;
-      });
 
       cy.contains(
         'By clicking here you are indicating that you have read and agree to our',
@@ -247,6 +259,10 @@ describe('Wallet App Test Cases', () => {
         .find('input[type="checkbox"]')
         .click();
       cy.contains('Proceed').click();
+
+      cy.acceptAccess().then(taskCompleted => {
+        expect(taskCompleted).to.be.true;
+      });
 
       cy.acceptAccess().then(taskCompleted => {
         expect(taskCompleted).to.be.true;

--- a/test/e2e/specs/liquidation.spec.js
+++ b/test/e2e/specs/liquidation.spec.js
@@ -5,6 +5,7 @@ import {
   LIQUIDATING_TIMEOUT,
   LIQUIDATED_TIMEOUT,
   econGovURL,
+  MINUTE_MS,
 } from '../test.utils';
 
 describe('Wallet App Test Cases', () => {
@@ -131,7 +132,7 @@ describe('Wallet App Test Cases', () => {
     });
 
     it('should wait for proposal to pass', () => {
-      cy.wait(60000 - Date.now() + startTime);
+      cy.wait(MINUTE_MS - Date.now() + startTime);
       cy.visit(econGovURL);
 
       cy.get('button').contains('History').click();
@@ -229,7 +230,7 @@ describe('Wallet App Test Cases', () => {
     });
 
     it('should wait for proposal to pass', () => {
-      cy.wait(60000 - Date.now() + startTime);
+      cy.wait(MINUTE_MS - Date.now() + startTime);
       cy.visit(econGovURL);
 
       cy.get('button').contains('History').click();

--- a/test/e2e/specs/liquidation.spec.js
+++ b/test/e2e/specs/liquidation.spec.js
@@ -6,9 +6,17 @@ import {
 } from '../test.utils';
 
 describe('Wallet App Test Cases', () => {
+  let startTime;
+
   context('Setting up accounts', () => {
     // Using exports from the synthetic-chain lib instead of hardcoding mnemonics UNTIL https://github.com/Agoric/agoric-3-proposals/issues/154
     it('should set up wallets', () => {
+      cy.setupWallet({
+        secretWords: mnemonics.user1,
+        walletName: 'user1',
+      }).then(taskCompleted => {
+        expect(taskCompleted).to.be.true;
+      });
       cy.setupWallet({
         secretWords: mnemonics.gov1,
         walletName: 'gov1',
@@ -21,17 +29,210 @@ describe('Wallet App Test Cases', () => {
       }).then(taskCompleted => {
         expect(taskCompleted).to.be.true;
       });
-      cy.setupWallet({
-        secretWords: mnemonics.user1,
-        walletName: 'user1',
-      }).then(taskCompleted => {
-        expect(taskCompleted).to.be.true;
-      });
+    });
+  });
+
+  context('Adjusting manager params from econ-gov', () => {
+    it('should connect with chain and wallet', () => {
+      cy.visit('https://econ-gov.inter.trade/?agoricNet=local');
+      cy.acceptAccess();
+    });
+    it('should allow gov2 to create a proposal', () => {
+      cy.visit('https://econ-gov.inter.trade/?agoricNet=local');
+      cy.acceptAccess();
+
+      cy.get('button').contains('Vaults').click();
+      cy.get('button').contains('Select Manager').click();
+      cy.get('button').contains('manager0').click();
+
+      cy.get('label')
+        .contains('LiquidationMargin')
+        .parent()
+        .within(() => {
+          cy.get('input').clear().type('150');
+        });
+
+      cy.get('label')
+        .contains('LiquidationPadding')
+        .parent()
+        .within(() => {
+          cy.get('input').clear().type('25');
+        });
+
+      cy.get('label')
+        .contains('LiquidationPenalty')
+        .parent()
+        .within(() => {
+          cy.get('input').clear().type('1');
+        });
+
+      cy.get('label')
+        .contains('StabilityFee')
+        .parent()
+        .within(() => {
+          cy.get('input').clear().type('1');
+        });
+
+      cy.get('label')
+        .contains('MintFee')
+        .parent()
+        .within(() => {
+          cy.get('input').clear().type('0.5');
+        });
+
+      cy.get('label')
+        .contains('Minutes until close of vote')
+        .parent()
+        .within(() => {
+          cy.get('input').clear().type(1);
+        });
+      cy.get('[value="Propose Parameter Change"]').click();
+
+      cy.confirmTransaction();
+      cy.get('p')
+        .contains('sent')
+        .should('be.visible')
+        .then(() => {
+          startTime = Date.now();
+        });
+    });
+
+    it('should allow gov2 to vote on the proposal', () => {
+      cy.visit('https://econ-gov.inter.trade/?agoricNet=local');
+
+      cy.get('button').contains('Vote').click();
+      cy.get('p').contains('YES').click();
+      cy.get('input:enabled[value="Submit Vote"]').click();
+
+      cy.confirmTransaction();
+      cy.get('p').contains('sent').should('be.visible');
+    });
+
+    it('should allow gov1 to vote on the proposal', () => {
+      cy.switchWallet('gov1');
+      cy.visit('https://econ-gov.inter.trade/?agoricNet=local');
+
+      cy.get('button').contains('Vote').click();
+      cy.get('p').contains('YES').click();
+      cy.get('input:enabled[value="Submit Vote"]').click();
+
+      cy.confirmTransaction();
+      cy.get('p').contains('sent').should('be.visible');
+    });
+
+    it('should wait for proposal to pass', () => {
+      cy.wait(60000 - Date.now() + startTime);
+      cy.visit('https://econ-gov.inter.trade/?agoricNet=local');
+
+      cy.get('button').contains('History').click();
+
+      cy.get('code')
+        .contains('VaultFactory - ATOM')
+        .parent()
+        .parent()
+        .parent()
+        .within(() => {
+          cy.get('span').contains('Change Accepted').should('be.visible');
+        });
+    });
+  });
+
+  context('Adjusting auction params from econ-gov', () => {
+    it('should allow gov1 to create a proposal', () => {
+      cy.visit('https://econ-gov.inter.trade/?agoricNet=local');
+
+      cy.get('button').contains('Vaults').click();
+      cy.get('button').contains('Change Manager Params').click();
+      cy.get('button').contains('Change Auctioneer Params').click();
+
+      cy.get('label')
+        .contains('StartingRate')
+        .parent()
+        .within(() => {
+          cy.get('input').clear().type('10500');
+        });
+
+      cy.get('label')
+        .contains('LowestRate')
+        .parent()
+        .within(() => {
+          cy.get('input').clear().type('6500');
+        });
+
+      cy.get('label')
+        .contains('DiscountStep')
+        .parent()
+        .within(() => {
+          cy.get('input').clear().type('500');
+        });
+
+      cy.get('label')
+        .contains('AuctionStartDelay')
+        .parent()
+        .within(() => {
+          cy.get('input').clear().type('2');
+        });
+
+      cy.get('label')
+        .contains('Minutes until close of vote')
+        .parent()
+        .within(() => {
+          cy.get('input').clear().type(1);
+        });
+      cy.get('[value="Propose Parameter Change"]').click();
+
+      cy.confirmTransaction();
+      cy.get('p')
+        .contains('sent')
+        .should('be.visible')
+        .then(() => {
+          startTime = Date.now();
+        });
+    });
+
+    it('should allow gov1 to vote on the proposal', () => {
+      cy.visit('https://econ-gov.inter.trade/?agoricNet=local');
+
+      cy.get('button').contains('Vote').click();
+      cy.get('p').contains('YES').click();
+      cy.get('input:enabled[value="Submit Vote"]').click();
+
+      cy.confirmTransaction();
+      cy.get('p').contains('sent').should('be.visible');
+    });
+
+    it('should allow gov2 to vote on the proposal', () => {
+      cy.switchWallet('gov2');
+      cy.visit('https://econ-gov.inter.trade/?agoricNet=local');
+
+      cy.get('button').contains('Vote').click();
+      cy.get('p').contains('YES').click();
+      cy.get('input:enabled[value="Submit Vote"]').click();
+
+      cy.confirmTransaction();
+      cy.get('p').contains('sent').should('be.visible');
+    });
+
+    it('should wait for proposal to pass', () => {
+      cy.wait(60000 - Date.now() + startTime);
+      cy.visit('https://econ-gov.inter.trade/?agoricNet=local');
+
+      cy.get('button').contains('History').click();
+
+      cy.get('code')
+        .contains('VaultFactory - ATOM')
+        .parent()
+        .parent()
+        .parent()
+        .within(() => {
+          cy.get('span').contains('Change Accepted').should('be.visible');
+        });
     });
   });
 
   context('Creating vaults and changing ATOM price', () => {
     it('should connect with the wallet', () => {
+      cy.switchWallet('user1');
       cy.visit('/');
 
       cy.contains('Connect Wallet').click();

--- a/test/e2e/support.js
+++ b/test/e2e/support.js
@@ -1,11 +1,13 @@
 import '@agoric/synpress/support/index';
-import { accountAddresses } from './test.utils';
+import { accountAddresses, AGORIC_NET } from './test.utils';
 
 Cypress.Commands.add('addKeys', params => {
   const { keyName, mnemonic, expectedAddress } = params;
   const command = `echo ${mnemonic} | agd keys add ${keyName} --recover --keyring-backend=test`;
 
-  cy.exec(command).then(({ stdout }) => {
+  cy.exec(command, {
+    env: { AGORIC_NET },
+  }).then(({ stdout }) => {
     expect(stdout).to.contain(expectedAddress);
   });
 });
@@ -13,6 +15,7 @@ Cypress.Commands.add('addKeys', params => {
 Cypress.Commands.add('setOraclePrice', price => {
   cy.exec(
     `agops oracle setPrice --keys gov1,gov2 --pair ATOM.USD --price ${price} --keyring-backend=test`,
+    { env: { AGORIC_NET } },
   ).then(({ stdout }) => {
     expect(stdout).to.not.contain('Error');
     expect(stdout).to.not.contain('error');
@@ -27,12 +30,12 @@ Cypress.Commands.add('createVault', params => {
 
   const createVaultCommand = `agops vaults open --wantMinted "${wantMinted}" --giveCollateral "${giveCollateral}" > /tmp/want-ist.json`;
 
-  cy.exec(createVaultCommand).then(({ stdout }) => {
+  cy.exec(createVaultCommand, { env: { AGORIC_NET } }).then(({ stdout }) => {
     expect(stdout).not.to.contain('Error');
 
     const broadcastCommand = `agops perf satisfaction --executeOffer /tmp/want-ist.json --from "${accountAddress}" --keyring-backend=test`;
 
-    cy.exec(broadcastCommand).then(({ stdout }) => {
+    cy.exec(broadcastCommand, { env: { AGORIC_NET } }).then(({ stdout }) => {
       expect(stdout).not.to.contain('Error');
     });
   });
@@ -42,7 +45,7 @@ Cypress.Commands.add('placeBidByPrice', params => {
   const { fromAddress, giveAmount, price } = params;
   const command = `agops inter bid by-price --from ${fromAddress} --give ${giveAmount} --price ${price} --keyring-backend=test`;
 
-  cy.exec(command).then(({ stdout }) => {
+  cy.exec(command, { env: { AGORIC_NET } }).then(({ stdout }) => {
     expect(stdout).to.contain('Your bid has been accepted');
   });
 });
@@ -52,7 +55,7 @@ Cypress.Commands.add('placeBidByDiscount', params => {
 
   const command = `agops inter bid by-discount --from ${fromAddress} --give ${giveAmount} --discount ${discount} --keyring-backend=test`;
 
-  cy.exec(command).then(({ stdout }) => {
+  cy.exec(command, { env: { AGORIC_NET } }).then(({ stdout }) => {
     expect(stdout).to.contain('Your bid has been accepted');
   });
 });
@@ -61,6 +64,7 @@ Cypress.Commands.add('verifyAuctionData', (propertyName, expectedValue) => {
   return cy
     .exec(`agops inter auction status`, {
       failOnNonZeroExit: false,
+      env: { AGORIC_NET },
     })
     .then(({ stdout }) => {
       const output = JSON.parse(stdout);

--- a/test/e2e/test.utils.js
+++ b/test/e2e/test.utils.js
@@ -25,3 +25,5 @@ export const phrasesList = {
     isLocal: true,
   },
 };
+
+export const econGovURL = 'https://econ-gov.inter.trade/?agoricNet=local';

--- a/test/e2e/test.utils.js
+++ b/test/e2e/test.utils.js
@@ -14,6 +14,7 @@ export const accountAddresses = {
 export const LIQUIDATING_TIMEOUT = 20 * 60 * 1000;
 export const LIQUIDATED_TIMEOUT = 10 * 60 * 1000;
 export const MINUTE_MS = 60000;
+export const AGORIC_NET = 'local';
 
 export const phrasesList = {
   emerynet: {


### PR DESCRIPTION
The PR does the following:
- Setup manager params from econ-gov.
- Setup auctioneer params from econ-gov. 
- Changes in setting up wallet test case for dapp-inter. 
- Exporting `AGORIC_NET` when running shell commands. This will assist when setting up these tests with emerynet. 