### PR TITLE
cleanup tests for emerynet 

### DIFF
--- a/test/e2e/specs/liquidation-reconstitution.spec.js
+++ b/test/e2e/specs/liquidation-reconstitution.spec.js
@@ -511,6 +511,11 @@ describe('Wallet App Test Cases', () => {
           );
         });
       });
+
+      it('should set ATOM price back to 12.34', () => {
+        cy.skipWhen(AGORIC_NET === networks.LOCAL);
+        cy.setOraclePrice(12.34);
+      });
     },
   );
 });

--- a/test/e2e/specs/liquidation.spec.js
+++ b/test/e2e/specs/liquidation.spec.js
@@ -503,5 +503,10 @@ describe('Wallet App Test Cases', () => {
         });
       },
     );
+
+    it('should set ATOM price back to 12.34', () => {
+      cy.skipWhen(AGORIC_NET === networks.LOCAL);
+      cy.setOraclePrice(12.34);
+    });
   });
 });

--- a/test/e2e/specs/liquidation.spec.js
+++ b/test/e2e/specs/liquidation.spec.js
@@ -5,6 +5,7 @@ import {
   MINUTE_MS,
   networks,
   configMap,
+  webWalletURL,
 } from '../test.utils';
 
 describe('Wallet App Test Cases', () => {
@@ -507,6 +508,66 @@ describe('Wallet App Test Cases', () => {
     it('should set ATOM price back to 12.34', () => {
       cy.skipWhen(AGORIC_NET === networks.LOCAL);
       cy.setOraclePrice(12.34);
+    });
+
+    it('should setup the web wallet and cancel the 150IST bid', () => {
+      cy.skipWhen(AGORIC_NET === networks.LOCAL);
+
+      cy.switchWallet(bidderWalletName);
+
+      cy.visit(webWalletURL);
+
+      cy.acceptAccess().then(taskCompleted => {
+        expect(taskCompleted).to.be.true;
+      });
+
+      cy.visit(`${webWalletURL}/wallet/`);
+
+      cy.get('input[type="checkbox"]').check();
+      cy.contains('Proceed').click();
+      cy.get('button[aria-label="Settings"]').click();
+
+      cy.contains('div', 'Mainnet').click();
+      cy.contains('li', 'Emerynet').click();
+      cy.contains('button', 'Connect').click();
+
+      cy.acceptAccess().then(taskCompleted => {
+        expect(taskCompleted).to.be.true;
+      });
+
+      cy.reload();
+
+      cy.acceptAccess().then(taskCompleted => {
+        expect(taskCompleted).to.be.true;
+      });
+
+      cy.get('span')
+        .contains('ATOM', { timeout: DEFAULT_TIMEOUT })
+        .should('exist');
+      cy.get('span')
+        .contains('BLD', { timeout: DEFAULT_TIMEOUT })
+        .should('exist');
+
+      // Verify completely filled bids
+      cy.contains('90.00 IST', { timeout: DEFAULT_TIMEOUT }).should(
+        'not.exist',
+      );
+      cy.contains('80.00 IST', { timeout: DEFAULT_TIMEOUT }).should(
+        'not.exist',
+      );
+      // Verify 150 IST Bid to exist
+      cy.contains('150.00 IST', { timeout: DEFAULT_TIMEOUT }).should('exist');
+
+      cy.getTokenAmount('IST').then(initialTokenValue => {
+        cy.contains('Exit').click();
+        cy.acceptAccess().then(taskCompleted => {
+          expect(taskCompleted).to.be.true;
+        });
+        cy.contains('Accepted', { timeout: DEFAULT_TIMEOUT }).should('exist');
+        cy.getTokenAmount('IST').then(tokenValue => {
+          expect(tokenValue).to.greaterThan(initialTokenValue);
+        });
+      });
     });
   });
 });

--- a/test/e2e/test.utils.js
+++ b/test/e2e/test.utils.js
@@ -11,6 +11,7 @@ export const accountAddresses = {
   gov2: 'agoric1wrfh296eu2z34p6pah7q04jjuyj3mxu9v98277',
 };
 
+export const webWalletURL = 'https://wallet.agoric.app/';
 export const COMMAND_TIMEOUT = 4 * 60 * 1000;
 export const LIQUIDATING_TIMEOUT = 20 * 60 * 1000;
 export const LIQUIDATED_TIMEOUT = 10 * 60 * 1000;


### PR DESCRIPTION
The PR does the following:
- Implements a test to reset the ATOM price to `12.34` in Emerynet, ensuring the resumption of normal operations.
- Adds a test to remove the `150 IST` bid in the liquidation happy path tests, to prevent any impact on subsequent test runs.