### PR TITLE
ci: artifacts setup for dapp-inter

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,4 @@
 node_modules/
 docker
+# Ignore generated credentials from google-github-actions/auth
+gha-creds-*.json

--- a/.eslintignore
+++ b/.eslintignore
@@ -3,4 +3,5 @@ coverage
 dist
 patches
 yarn.lock
-
+# Ignore generated credentials from google-github-actions/auth
+gha-creds-*.json

--- a/.github/workflows/reusable-workflow.yml
+++ b/.github/workflows/reusable-workflow.yml
@@ -35,9 +35,20 @@ jobs:
   e2e:
     runs-on: ubuntu-latest
 
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
+
+      - name: 'GCP auth'
+        uses: 'google-github-actions/auth@v2'
+        if: ${{ inputs.is_emerynet_test }}
+        with:
+          project_id: 'simulationlab'
+          workload_identity_provider: 'projects/60745596728/locations/global/workloadIdentityPools/github/providers/dapp-inter'
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
@@ -89,9 +100,9 @@ jobs:
           CYPRESS_BIDDER_MNEMONIC_INPUT: ${{ inputs.bidder_mnemonic }}
           CYPRESS_BIDDER_ADDRESS_INPUT: ${{ inputs.bidder_address }}
 
-      - name: Archive e2e artifacts
-        uses: actions/upload-artifact@v3
-        if: always()
+      - name: Upload e2e artifacts as workflow artifacts
+        uses: actions/upload-artifact@v4
+        if: ${{ inputs.is_emerynet_test && !cancelled() }}
         with:
           name: e2e-artifacts
           path: |
@@ -99,3 +110,15 @@ jobs:
             test/e2e/docker/videos-ci
             test/e2e/docker/screenshots
         continue-on-error: true
+
+      - name: Upload e2e artifacts to GCP
+        uses: google-github-actions/upload-cloud-storage@v2
+        if: ${{ inputs.is_emerynet_test && !cancelled() }}
+        with:
+          path: 'test/e2e/docker'
+          destination: 'github-artifacts/${{ github.repository }}/${{ github.run_id }}/${{ github.event.repository.updated_at }}'
+        continue-on-error: true
+
+      - name: Log Path to GCS artifacts
+        if: ${{ inputs.is_emerynet_test && !cancelled() }}
+        run: echo "https://console.cloud.google.com/storage/browser/github-artifacts/${{ github.repository }}/${{ github.run_id }}/${{ github.event.repository.updated_at }}/docker/videos"

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,5 @@ screenshots
 videos
 cypress
 docker
+# Ignore generated credentials from google-github-actions/auth
+gha-creds-*.json

--- a/.prettierignore
+++ b/.prettierignore
@@ -3,3 +3,5 @@ node_modules
 yarn.lock
 coverage
 patches
+# Ignore generated credentials from google-github-actions/auth
+gha-creds-*.json


### PR DESCRIPTION
This pull request enables the uploading of end-to-end tests to Google Cloud Platform (GCP).

I tested this workflow in this [GitHub Action run](https://github.com/Agoric/dapp-inter/actions/runs/9352479080/job/25740739716?pr=297) by making a dummy commit.