### PR TITLE
passing env variables to the reusable workflow

### DIFF
--- a/.github/workflows/liquidation-reconstitution.yml
+++ b/.github/workflows/liquidation-reconstitution.yml
@@ -48,3 +48,5 @@ jobs:
       user1_address: ${{ inputs.user1_address }}
       bidder_mnemonic: ${{ inputs.bidder_mnemonic }}
       bidder_address: ${{ inputs.bidder_address }}
+
+    secrets: inherit

--- a/.github/workflows/liquidation.yml
+++ b/.github/workflows/liquidation.yml
@@ -1,6 +1,10 @@
 name: Liquidation E2E tests
 
 on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
   schedule:
     - cron: '0 0 * * *'
   workflow_dispatch:
@@ -43,7 +47,7 @@ jobs:
         docker-compose -f test/e2e/docker-compose-liquidation.yml \
         --profile synpress up --build \
         --exit-code-from synpress
-      is_emerynet_test: ${{ inputs.network == 'emerynet' }}
+      is_emerynet_test: ${{ 'emerynet' == 'emerynet' }}
       user1_mnemonic: ${{ inputs.user1_mnemonic }}
       user1_address: ${{ inputs.user1_address }}
       bidder_mnemonic: ${{ inputs.bidder_mnemonic }}

--- a/.github/workflows/liquidation.yml
+++ b/.github/workflows/liquidation.yml
@@ -1,10 +1,6 @@
 name: Liquidation E2E tests
 
 on:
-  push:
-    branches: [main]
-  pull_request:
-    branches: [main]
   schedule:
     - cron: '0 0 * * *'
   workflow_dispatch:
@@ -47,8 +43,10 @@ jobs:
         docker-compose -f test/e2e/docker-compose-liquidation.yml \
         --profile synpress up --build \
         --exit-code-from synpress
-      is_emerynet_test: ${{ 'emerynet' == 'emerynet' }}
+      is_emerynet_test: ${{ inputs.network == 'emerynet' }}
       user1_mnemonic: ${{ inputs.user1_mnemonic }}
       user1_address: ${{ inputs.user1_address }}
       bidder_mnemonic: ${{ inputs.bidder_mnemonic }}
       bidder_address: ${{ inputs.bidder_address }}
+
+    secrets: inherit

--- a/test/e2e/specs/liquidation.spec.js
+++ b/test/e2e/specs/liquidation.spec.js
@@ -25,549 +25,555 @@ describe('Wallet App Test Cases', () => {
   const gov2Address = currentConfig.gov2Address;
   const econGovURL = currentConfig.econGovURL;
 
-  context('Setting up accounts', () => {
-    // Using exports from the synthetic-chain lib instead of hardcoding mnemonics UNTIL https://github.com/Agoric/agoric-3-proposals/issues/154
-    it('should set up bidder wallet', () => {
-      cy.skipWhen(AGORIC_NET === networks.LOCAL);
-
-      cy.setupWallet({
-        secretWords: bidderMnemonic,
-        walletName: bidderWalletName,
-      }).then(taskCompleted => {
-        expect(taskCompleted).to.be.true;
-      });
-    });
-
-    it('should set up user1 wallet', () => {
-      cy.setupWallet({
-        secretWords: user1Mnemonic,
-        walletName: 'user1',
-      }).then(taskCompleted => {
-        expect(taskCompleted).to.be.true;
-      });
-    });
-
-    it('should set up gov1 wallet', () => {
-      cy.skipWhen(AGORIC_NET === networks.EMERYNET);
-
-      cy.setupWallet({
-        secretWords: mnemonics.gov1,
-        walletName: 'gov1',
-      }).then(taskCompleted => {
-        expect(taskCompleted).to.be.true;
-      });
-    });
-
-    it('should set up gov2 wallet', () => {
-      cy.skipWhen(AGORIC_NET === networks.EMERYNET);
-
-      cy.setupWallet({
-        secretWords: mnemonics.gov2,
-        walletName: 'gov2',
-      }).then(taskCompleted => {
-        expect(taskCompleted).to.be.true;
-      });
-    });
-  });
-
-  context('Adjusting manager params from econ-gov', () => {
-    it('should connect with chain and wallet', () => {
-      cy.skipWhen(AGORIC_NET === networks.EMERYNET);
-
-      cy.visit(econGovURL);
-      cy.acceptAccess().then(taskCompleted => {
-        expect(taskCompleted).to.be.true;
-      });
-    });
-    it('should allow gov2 to create a proposal', () => {
-      cy.skipWhen(AGORIC_NET === networks.EMERYNET);
-
-      cy.visit(econGovURL);
-      cy.acceptAccess();
-
-      cy.get('button').contains('Vaults').click();
-      cy.get('button').contains('Select Manager').click();
-      cy.get('button').contains('manager0').click();
-
-      cy.get('label')
-        .contains('LiquidationMargin')
-        .parent()
-        .within(() => {
-          cy.get('input').clear();
-          cy.get('input').type('150');
-        });
-
-      cy.get('label')
-        .contains('LiquidationPadding')
-        .parent()
-        .within(() => {
-          cy.get('input').clear();
-          cy.get('input').type('25');
-        });
-
-      cy.get('label')
-        .contains('LiquidationPenalty')
-        .parent()
-        .within(() => {
-          cy.get('input').clear();
-          cy.get('input').type('1');
-        });
-
-      cy.get('label')
-        .contains('StabilityFee')
-        .parent()
-        .within(() => {
-          cy.get('input').clear();
-          cy.get('input').type('1');
-        });
-
-      cy.get('label')
-        .contains('MintFee')
-        .parent()
-        .within(() => {
-          cy.get('input').clear();
-          cy.get('input').type('0.5');
-        });
-
-      cy.get('label')
-        .contains('Minutes until close of vote')
-        .parent()
-        .within(() => {
-          cy.get('input').clear();
-          cy.get('input').type(1);
-        });
-      cy.get('[value="Propose Parameter Change"]').click();
-
-      cy.confirmTransaction();
-      cy.get('p')
-        .contains('sent')
-        .should('be.visible')
-        .then(() => {
-          startTime = Date.now();
-        });
-    });
-
-    it('should allow gov2 to vote on the proposal', () => {
-      cy.skipWhen(AGORIC_NET === networks.EMERYNET);
-      cy.visit(econGovURL);
-
-      cy.get('button').contains('Vote').click();
-      cy.get('p').contains('YES').click();
-      cy.get('input:enabled[value="Submit Vote"]').click();
-
-      cy.confirmTransaction();
-      cy.get('p').contains('sent').should('be.visible');
-    });
-
-    it('should allow gov1 to vote on the proposal', () => {
-      cy.skipWhen(AGORIC_NET === networks.EMERYNET);
-
-      cy.switchWallet('gov1');
-      cy.visit(econGovURL);
-
-      cy.get('button').contains('Vote').click();
-      cy.get('p').contains('YES').click();
-      cy.get('input:enabled[value="Submit Vote"]').click();
-
-      cy.confirmTransaction();
-      cy.get('p').contains('sent').should('be.visible');
-    });
-
-    it('should wait for proposal to pass', () => {
-      cy.skipWhen(AGORIC_NET === networks.EMERYNET);
-
-      cy.wait(MINUTE_MS - Date.now() + startTime);
-      cy.visit(econGovURL);
-
-      cy.get('button').contains('History').click();
-
-      cy.get('code')
-        .contains('VaultFactory - ATOM')
-        .parent()
-        .parent()
-        .parent()
-        .within(() => {
-          cy.get('span').contains('Change Accepted').should('be.visible');
-        });
-    });
-  });
-
-  context('Adjusting auction params from econ-gov', () => {
-    it('should allow gov1 to create a proposal', () => {
-      cy.skipWhen(AGORIC_NET === networks.EMERYNET);
-
-      cy.visit(econGovURL);
-
-      cy.get('button').contains('Vaults').click();
-      cy.get('button').contains('Change Manager Params').click();
-      cy.get('button').contains('Change Auctioneer Params').click();
-
-      cy.get('label')
-        .contains('StartingRate')
-        .parent()
-        .within(() => {
-          cy.get('input').clear();
-          cy.get('input').type('10500');
-        });
-
-      cy.get('label')
-        .contains('LowestRate')
-        .parent()
-        .within(() => {
-          cy.get('input').clear();
-          cy.get('input').type('6500');
-        });
-
-      cy.get('label')
-        .contains('DiscountStep')
-        .parent()
-        .within(() => {
-          cy.get('input').clear();
-          cy.get('input').type('500');
-        });
-
-      cy.get('label')
-        .contains('AuctionStartDelay')
-        .parent()
-        .within(() => {
-          cy.get('input').clear();
-          cy.get('input').type('2');
-        });
-
-      cy.get('label')
-        .contains('Minutes until close of vote')
-        .parent()
-        .within(() => {
-          cy.get('input').clear();
-          cy.get('input').type(1);
-        });
-      cy.get('[value="Propose Parameter Change"]').click();
-
-      cy.confirmTransaction();
-      cy.get('p')
-        .contains('sent')
-        .should('be.visible')
-        .then(() => {
-          startTime = Date.now();
-        });
-    });
-
-    it('should allow gov1 to vote on the proposal', () => {
-      cy.skipWhen(AGORIC_NET === networks.EMERYNET);
-
-      cy.visit(econGovURL);
-
-      cy.get('button').contains('Vote').click();
-      cy.get('p').contains('YES').click();
-      cy.get('input:enabled[value="Submit Vote"]').click();
-
-      cy.confirmTransaction();
-      cy.get('p').contains('sent').should('be.visible');
-    });
-
-    it('should allow gov2 to vote on the proposal', () => {
-      cy.skipWhen(AGORIC_NET === networks.EMERYNET);
-
-      cy.switchWallet('gov2');
-      cy.visit(econGovURL);
-
-      cy.get('button').contains('Vote').click();
-      cy.get('p').contains('YES').click();
-      cy.get('input:enabled[value="Submit Vote"]').click();
-
-      cy.confirmTransaction();
-      cy.get('p').contains('sent').should('be.visible');
-    });
-
-    it('should wait for proposal to pass', () => {
-      cy.skipWhen(AGORIC_NET === networks.EMERYNET);
-
-      cy.wait(MINUTE_MS - Date.now() + startTime);
-      cy.visit(econGovURL);
-
-      cy.get('button').contains('History').click();
-
-      cy.get('code')
-        .contains('VaultFactory - ATOM')
-        .parent()
-        .parent()
-        .parent()
-        .within(() => {
-          cy.get('span').contains('Change Accepted').should('be.visible');
-        });
-
-      cy.switchWallet('user1');
-    });
-  });
-
-  context('Creating vaults and changing ATOM price', () => {
-    it(
-      'should connect with the wallet',
-      {
-        defaultCommandTimeout: DEFAULT_TIMEOUT,
-        taskTimeout: DEFAULT_TASK_TIMEOUT,
-      },
-      () => {
-        cy.connectWithWallet();
-      },
-    );
-
-    it('should add all the keys successfully', () => {
-      cy.addKeys({
-        keyName: 'gov1',
-        mnemonic: gov1Mnemonic,
-        expectedAddress: gov1Address,
-      });
-      cy.addKeys({
-        keyName: 'gov2',
-        mnemonic: gov2Mnemonic,
-        expectedAddress: gov2Address,
-      });
-      cy.addKeys({
-        keyName: 'user1',
-        mnemonic: user1Mnemonic,
-        expectedAddress: user1Address,
-      });
-    });
-
-    it('should add the bidder key successfully', () => {
-      cy.skipWhen(AGORIC_NET === networks.LOCAL);
-      cy.addKeys({
-        keyName: 'bidder',
-        mnemonic: bidderMnemonic,
-        expectedAddress: bidderAddress,
-      });
-    });
-    it('should set ATOM price to 12.34', () => {
-      cy.setOraclePrice(12.34);
-    });
-
-    it('should create a vault minting 100 ISTs and giving 15 ATOMs as collateral', () => {
-      cy.createVault({ wantMinted: 100, giveCollateral: 15, userKey: 'user1' });
-    });
-
-    it('should create a vault minting 103 ISTs and giving 15 ATOMs as collateral', () => {
-      cy.createVault({ wantMinted: 103, giveCollateral: 15, userKey: 'user1' });
-    });
-
-    it('should create a vault minting 105 ISTs and giving 15 ATOMs as collateral', () => {
-      cy.createVault({ wantMinted: 105, giveCollateral: 15, userKey: 'user1' });
-    });
-
-    it(
-      'should check for the existence of vaults on the UI',
-      {
-        defaultCommandTimeout: DEFAULT_TIMEOUT,
-        taskTimeout: DEFAULT_TASK_TIMEOUT,
-      },
-      () => {
-        cy.contains('button', 'Back to vaults').click();
-        cy.scrollTo('bottom', { ensureScrollable: false });
-        cy.contains('100.50 IST').should('exist');
-        cy.contains('103.51 IST').should('exist');
-        cy.contains('105.52 IST').should('exist');
-      },
-    );
-  });
-
-  context('Place bids and make all vaults enter liquidation', () => {
-    it('should create a vault minting 400 ISTs and giving 80 ATOMs as collateral', () => {
-      cy.skipWhen(AGORIC_NET === networks.EMERYNET);
-      cy.createVault({ wantMinted: 400, giveCollateral: 80, userKey: 'gov1' });
-    });
-
-    it(
-      'should place bids from the CLI successfully',
-      {
-        defaultCommandTimeout: DEFAULT_TIMEOUT,
-        taskTimeout: DEFAULT_TASK_TIMEOUT,
-      },
-      () => {
-        cy.switchWallet(bidderWalletName);
-        cy.addNewTokensFound();
-        cy.getTokenAmount('IST').then(initialTokenValue => {
-          cy.placeBidByPrice({
-            fromAddress: bidderAddress,
-            giveAmount: '90IST',
-            price: 9,
-          });
-
-          cy.placeBidByDiscount({
-            fromAddress: bidderAddress,
-            giveAmount: '80IST',
-            discount: 10,
-          });
-
-          cy.placeBidByDiscount({
-            fromAddress: bidderAddress,
-            giveAmount: '150IST',
-            discount: 15,
-          });
-
-          cy.getTokenAmount('IST').then(tokenValue => {
-            expect(tokenValue).to.lessThan(initialTokenValue);
-          });
-        });
-      },
-    );
-
-    it('should verify vaults that are at a risk of being liquidated', () => {
-      cy.setOraclePrice(9.99);
-      cy.switchWallet('user1');
-      cy.contains(
-        /Please increase your collateral or repay your outstanding IST debt./,
-      );
-    });
-
-    it('should wait and verify vaults are being liquidated', () => {
-      cy.contains(/3 vaults are liquidating./, {
-        timeout: LIQUIDATING_TIMEOUT,
-      });
-    });
-
-    it('should verify the value of startPrice from the CLI successfully', () => {
-      const propertyName = 'book0.startPrice';
-      const expectedValue = '9.99 IST/ATOM';
-
-      cy.verifyAuctionData(propertyName, expectedValue);
-    });
-
-    it('should verify the value of startProceedsGoal from the CLI successfully', () => {
-      const propertyName = 'book0.startProceedsGoal';
-      const expectedValue = '309.54 IST';
-
-      cy.verifyAuctionData(propertyName, expectedValue);
-    });
-
-    it('should verify the value of startCollateral from the CLI successfully', () => {
-      const propertyName = 'book0.startCollateral';
-      const expectedValue = '45 ATOM';
-
-      cy.verifyAuctionData(propertyName, expectedValue);
-    });
-
-    it('should verify the value of collateralAvailable from the CLI successfully', () => {
-      const propertyName = 'book0.collateralAvailable';
-      const expectedValue = '45 ATOM';
-
-      cy.verifyAuctionData(propertyName, expectedValue);
-    });
-
-    // Tests ran fine locally but failed in CI. Updating a3p container replicated failure locally. Tests pass with older container version.
-    // UNTIL: a3p container compatibility is resolved.
-    it(
-      'should wait and verify vaults are liquidated',
-      {
-        defaultCommandTimeout: DEFAULT_TIMEOUT,
-        taskTimeout: DEFAULT_TASK_TIMEOUT,
-      },
-      () => {
-        cy.skipWhen(AGORIC_NET === networks.LOCAL);
-
-        cy.contains(/Collateral left to claim/, {
-          timeout: LIQUIDATED_TIMEOUT,
-        });
-        cy.contains(/3.42 ATOM/);
-        cy.contains(/3.07 ATOM/);
-        cy.contains(/2.84 ATOM/);
-      },
-    );
-
-    it('should verify the value of collateralAvailable from the CLI successfully', () => {
-      cy.skipWhen(AGORIC_NET === networks.LOCAL);
-
-      const propertyName = 'book0.collateralAvailable';
-      const expectedValue = '9.659302 ATOM';
-
-      cy.verifyAuctionData(propertyName, expectedValue);
-    });
-
-    it(
-      'should claim collateral from all vaults successfully',
-      {
-        defaultCommandTimeout: DEFAULT_TIMEOUT,
-        taskTimeout: DEFAULT_TASK_TIMEOUT,
-      },
-      () => {
-        cy.skipWhen(AGORIC_NET === networks.LOCAL);
-
-        cy.get('span:contains("Click to claim collateral")').then(elements => {
-          expect(elements.length).to.be.at.least(3);
-          elements.slice(0, 3).each((index, element) => {
-            cy.wrap(element).click();
-            cy.contains('button', 'Close Out Vault').click();
-            cy.acceptAccess().then(taskCompleted => {
-              expect(taskCompleted).to.be.true;
-              cy.contains('button', 'Close Out Vault').should('not.exist');
-            });
-          });
-        });
-      },
-    );
-
-    it('should set ATOM price back to 12.34', () => {
-      cy.skipWhen(AGORIC_NET === networks.LOCAL);
-      cy.setOraclePrice(12.34);
-    });
-
-    it('should setup the web wallet and cancel the 150IST bid', () => {
-      cy.skipWhen(AGORIC_NET === networks.LOCAL);
-
-      cy.switchWallet(bidderWalletName);
-
-      cy.visit(webWalletURL);
-
-      cy.acceptAccess().then(taskCompleted => {
-        expect(taskCompleted).to.be.true;
-      });
-
-      cy.visit(`${webWalletURL}/wallet/`);
-
-      cy.get('input[type="checkbox"]').check();
-      cy.contains('Proceed').click();
-      cy.get('button[aria-label="Settings"]').click();
-
-      cy.contains('div', 'Mainnet').click();
-      cy.contains('li', 'Emerynet').click();
-      cy.contains('button', 'Connect').click();
-
-      cy.acceptAccess().then(taskCompleted => {
-        expect(taskCompleted).to.be.true;
-      });
-
-      cy.reload();
-
-      cy.acceptAccess().then(taskCompleted => {
-        expect(taskCompleted).to.be.true;
-      });
-
-      cy.get('span')
-        .contains('ATOM', { timeout: DEFAULT_TIMEOUT })
-        .should('exist');
-      cy.get('span')
-        .contains('BLD', { timeout: DEFAULT_TIMEOUT })
-        .should('exist');
-
-      // Verify completely filled bids
-      cy.contains('90.00 IST', { timeout: DEFAULT_TIMEOUT }).should(
-        'not.exist',
-      );
-      cy.contains('80.00 IST', { timeout: DEFAULT_TIMEOUT }).should(
-        'not.exist',
-      );
-      // Verify 150 IST Bid to exist
-      cy.contains('150.00 IST', { timeout: DEFAULT_TIMEOUT }).should('exist');
-
-      cy.getTokenAmount('IST').then(initialTokenValue => {
-        cy.contains('Exit').click();
-        cy.acceptAccess().then(taskCompleted => {
-          expect(taskCompleted).to.be.true;
-        });
-        cy.contains('Accepted', { timeout: DEFAULT_TIMEOUT }).should('exist');
-        cy.getTokenAmount('IST').then(tokenValue => {
-          expect(tokenValue).to.greaterThan(initialTokenValue);
-        });
-      });
-    });
-  });
+  it("DUMMY", () => {
+    cy.log(`AGORIC ${AGORIC_NET}......USER1ADDR:${user1Address}`)
+    cy.log(`BIDDER ${bidderAddress} Gov1ADDR: ${gov1Address} gov2ADDr: ${gov2Address}`)
+    cy.wait(2 * 60 * 1000)
+  })
+
+  // context('Setting up accounts', () => {
+  //   // Using exports from the synthetic-chain lib instead of hardcoding mnemonics UNTIL https://github.com/Agoric/agoric-3-proposals/issues/154
+  //   it('should set up bidder wallet', () => {
+  //     cy.skipWhen(AGORIC_NET === networks.LOCAL);
+
+  //     cy.setupWallet({
+  //       secretWords: bidderMnemonic,
+  //       walletName: bidderWalletName,
+  //     }).then(taskCompleted => {
+  //       expect(taskCompleted).to.be.true;
+  //     });
+  //   });
+
+  //   it('should set up user1 wallet', () => {
+  //     cy.setupWallet({
+  //       secretWords: user1Mnemonic,
+  //       walletName: 'user1',
+  //     }).then(taskCompleted => {
+  //       expect(taskCompleted).to.be.true;
+  //     });
+  //   });
+
+  //   it('should set up gov1 wallet', () => {
+  //     cy.skipWhen(AGORIC_NET === networks.EMERYNET);
+
+  //     cy.setupWallet({
+  //       secretWords: mnemonics.gov1,
+  //       walletName: 'gov1',
+  //     }).then(taskCompleted => {
+  //       expect(taskCompleted).to.be.true;
+  //     });
+  //   });
+
+  //   it('should set up gov2 wallet', () => {
+  //     cy.skipWhen(AGORIC_NET === networks.EMERYNET);
+
+  //     cy.setupWallet({
+  //       secretWords: mnemonics.gov2,
+  //       walletName: 'gov2',
+  //     }).then(taskCompleted => {
+  //       expect(taskCompleted).to.be.true;
+  //     });
+  //   });
+  // });
+
+  // context('Adjusting manager params from econ-gov', () => {
+  //   it('should connect with chain and wallet', () => {
+  //     cy.skipWhen(AGORIC_NET === networks.EMERYNET);
+
+  //     cy.visit(econGovURL);
+  //     cy.acceptAccess().then(taskCompleted => {
+  //       expect(taskCompleted).to.be.true;
+  //     });
+  //   });
+  //   it('should allow gov2 to create a proposal', () => {
+  //     cy.skipWhen(AGORIC_NET === networks.EMERYNET);
+
+  //     cy.visit(econGovURL);
+  //     cy.acceptAccess();
+
+  //     cy.get('button').contains('Vaults').click();
+  //     cy.get('button').contains('Select Manager').click();
+  //     cy.get('button').contains('manager0').click();
+
+  //     cy.get('label')
+  //       .contains('LiquidationMargin')
+  //       .parent()
+  //       .within(() => {
+  //         cy.get('input').clear();
+  //         cy.get('input').type('150');
+  //       });
+
+  //     cy.get('label')
+  //       .contains('LiquidationPadding')
+  //       .parent()
+  //       .within(() => {
+  //         cy.get('input').clear();
+  //         cy.get('input').type('25');
+  //       });
+
+  //     cy.get('label')
+  //       .contains('LiquidationPenalty')
+  //       .parent()
+  //       .within(() => {
+  //         cy.get('input').clear();
+  //         cy.get('input').type('1');
+  //       });
+
+  //     cy.get('label')
+  //       .contains('StabilityFee')
+  //       .parent()
+  //       .within(() => {
+  //         cy.get('input').clear();
+  //         cy.get('input').type('1');
+  //       });
+
+  //     cy.get('label')
+  //       .contains('MintFee')
+  //       .parent()
+  //       .within(() => {
+  //         cy.get('input').clear();
+  //         cy.get('input').type('0.5');
+  //       });
+
+  //     cy.get('label')
+  //       .contains('Minutes until close of vote')
+  //       .parent()
+  //       .within(() => {
+  //         cy.get('input').clear();
+  //         cy.get('input').type(1);
+  //       });
+  //     cy.get('[value="Propose Parameter Change"]').click();
+
+  //     cy.confirmTransaction();
+  //     cy.get('p')
+  //       .contains('sent')
+  //       .should('be.visible')
+  //       .then(() => {
+  //         startTime = Date.now();
+  //       });
+  //   });
+
+  //   it('should allow gov2 to vote on the proposal', () => {
+  //     cy.skipWhen(AGORIC_NET === networks.EMERYNET);
+  //     cy.visit(econGovURL);
+
+  //     cy.get('button').contains('Vote').click();
+  //     cy.get('p').contains('YES').click();
+  //     cy.get('input:enabled[value="Submit Vote"]').click();
+
+  //     cy.confirmTransaction();
+  //     cy.get('p').contains('sent').should('be.visible');
+  //   });
+
+  //   it('should allow gov1 to vote on the proposal', () => {
+  //     cy.skipWhen(AGORIC_NET === networks.EMERYNET);
+
+  //     cy.switchWallet('gov1');
+  //     cy.visit(econGovURL);
+
+  //     cy.get('button').contains('Vote').click();
+  //     cy.get('p').contains('YES').click();
+  //     cy.get('input:enabled[value="Submit Vote"]').click();
+
+  //     cy.confirmTransaction();
+  //     cy.get('p').contains('sent').should('be.visible');
+  //   });
+
+  //   it('should wait for proposal to pass', () => {
+  //     cy.skipWhen(AGORIC_NET === networks.EMERYNET);
+
+  //     cy.wait(MINUTE_MS - Date.now() + startTime);
+  //     cy.visit(econGovURL);
+
+  //     cy.get('button').contains('History').click();
+
+  //     cy.get('code')
+  //       .contains('VaultFactory - ATOM')
+  //       .parent()
+  //       .parent()
+  //       .parent()
+  //       .within(() => {
+  //         cy.get('span').contains('Change Accepted').should('be.visible');
+  //       });
+  //   });
+  // });
+
+  // context('Adjusting auction params from econ-gov', () => {
+  //   it('should allow gov1 to create a proposal', () => {
+  //     cy.skipWhen(AGORIC_NET === networks.EMERYNET);
+
+  //     cy.visit(econGovURL);
+
+  //     cy.get('button').contains('Vaults').click();
+  //     cy.get('button').contains('Change Manager Params').click();
+  //     cy.get('button').contains('Change Auctioneer Params').click();
+
+  //     cy.get('label')
+  //       .contains('StartingRate')
+  //       .parent()
+  //       .within(() => {
+  //         cy.get('input').clear();
+  //         cy.get('input').type('10500');
+  //       });
+
+  //     cy.get('label')
+  //       .contains('LowestRate')
+  //       .parent()
+  //       .within(() => {
+  //         cy.get('input').clear();
+  //         cy.get('input').type('6500');
+  //       });
+
+  //     cy.get('label')
+  //       .contains('DiscountStep')
+  //       .parent()
+  //       .within(() => {
+  //         cy.get('input').clear();
+  //         cy.get('input').type('500');
+  //       });
+
+  //     cy.get('label')
+  //       .contains('AuctionStartDelay')
+  //       .parent()
+  //       .within(() => {
+  //         cy.get('input').clear();
+  //         cy.get('input').type('2');
+  //       });
+
+  //     cy.get('label')
+  //       .contains('Minutes until close of vote')
+  //       .parent()
+  //       .within(() => {
+  //         cy.get('input').clear();
+  //         cy.get('input').type(1);
+  //       });
+  //     cy.get('[value="Propose Parameter Change"]').click();
+
+  //     cy.confirmTransaction();
+  //     cy.get('p')
+  //       .contains('sent')
+  //       .should('be.visible')
+  //       .then(() => {
+  //         startTime = Date.now();
+  //       });
+  //   });
+
+  //   it('should allow gov1 to vote on the proposal', () => {
+  //     cy.skipWhen(AGORIC_NET === networks.EMERYNET);
+
+  //     cy.visit(econGovURL);
+
+  //     cy.get('button').contains('Vote').click();
+  //     cy.get('p').contains('YES').click();
+  //     cy.get('input:enabled[value="Submit Vote"]').click();
+
+  //     cy.confirmTransaction();
+  //     cy.get('p').contains('sent').should('be.visible');
+  //   });
+
+  //   it('should allow gov2 to vote on the proposal', () => {
+  //     cy.skipWhen(AGORIC_NET === networks.EMERYNET);
+
+  //     cy.switchWallet('gov2');
+  //     cy.visit(econGovURL);
+
+  //     cy.get('button').contains('Vote').click();
+  //     cy.get('p').contains('YES').click();
+  //     cy.get('input:enabled[value="Submit Vote"]').click();
+
+  //     cy.confirmTransaction();
+  //     cy.get('p').contains('sent').should('be.visible');
+  //   });
+
+  //   it('should wait for proposal to pass', () => {
+  //     cy.skipWhen(AGORIC_NET === networks.EMERYNET);
+
+  //     cy.wait(MINUTE_MS - Date.now() + startTime);
+  //     cy.visit(econGovURL);
+
+  //     cy.get('button').contains('History').click();
+
+  //     cy.get('code')
+  //       .contains('VaultFactory - ATOM')
+  //       .parent()
+  //       .parent()
+  //       .parent()
+  //       .within(() => {
+  //         cy.get('span').contains('Change Accepted').should('be.visible');
+  //       });
+
+  //     cy.switchWallet('user1');
+  //   });
+  // });
+
+  // context('Creating vaults and changing ATOM price', () => {
+  //   it(
+  //     'should connect with the wallet',
+  //     {
+  //       defaultCommandTimeout: DEFAULT_TIMEOUT,
+  //       taskTimeout: DEFAULT_TASK_TIMEOUT,
+  //     },
+  //     () => {
+  //       cy.connectWithWallet();
+  //     },
+  //   );
+
+  //   it('should add all the keys successfully', () => {
+  //     cy.addKeys({
+  //       keyName: 'gov1',
+  //       mnemonic: gov1Mnemonic,
+  //       expectedAddress: gov1Address,
+  //     });
+  //     cy.addKeys({
+  //       keyName: 'gov2',
+  //       mnemonic: gov2Mnemonic,
+  //       expectedAddress: gov2Address,
+  //     });
+  //     cy.addKeys({
+  //       keyName: 'user1',
+  //       mnemonic: user1Mnemonic,
+  //       expectedAddress: user1Address,
+  //     });
+  //   });
+
+  //   it('should add the bidder key successfully', () => {
+  //     cy.skipWhen(AGORIC_NET === networks.LOCAL);
+  //     cy.addKeys({
+  //       keyName: 'bidder',
+  //       mnemonic: bidderMnemonic,
+  //       expectedAddress: bidderAddress,
+  //     });
+  //   });
+  //   it('should set ATOM price to 12.34', () => {
+  //     cy.setOraclePrice(12.34);
+  //   });
+
+  //   it('should create a vault minting 100 ISTs and giving 15 ATOMs as collateral', () => {
+  //     cy.createVault({ wantMinted: 100, giveCollateral: 15, userKey: 'user1' });
+  //   });
+
+  //   it('should create a vault minting 103 ISTs and giving 15 ATOMs as collateral', () => {
+  //     cy.createVault({ wantMinted: 103, giveCollateral: 15, userKey: 'user1' });
+  //   });
+
+  //   it('should create a vault minting 105 ISTs and giving 15 ATOMs as collateral', () => {
+  //     cy.createVault({ wantMinted: 105, giveCollateral: 15, userKey: 'user1' });
+  //   });
+
+  //   it(
+  //     'should check for the existence of vaults on the UI',
+  //     {
+  //       defaultCommandTimeout: DEFAULT_TIMEOUT,
+  //       taskTimeout: DEFAULT_TASK_TIMEOUT,
+  //     },
+  //     () => {
+  //       cy.contains('button', 'Back to vaults').click();
+  //       cy.scrollTo('bottom', { ensureScrollable: false });
+  //       cy.contains('100.50 IST').should('exist');
+  //       cy.contains('103.51 IST').should('exist');
+  //       cy.contains('105.52 IST').should('exist');
+  //     },
+  //   );
+  // });
+
+  // context('Place bids and make all vaults enter liquidation', () => {
+  //   it('should create a vault minting 400 ISTs and giving 80 ATOMs as collateral', () => {
+  //     cy.skipWhen(AGORIC_NET === networks.EMERYNET);
+  //     cy.createVault({ wantMinted: 400, giveCollateral: 80, userKey: 'gov1' });
+  //   });
+
+  //   it(
+  //     'should place bids from the CLI successfully',
+  //     {
+  //       defaultCommandTimeout: DEFAULT_TIMEOUT,
+  //       taskTimeout: DEFAULT_TASK_TIMEOUT,
+  //     },
+  //     () => {
+  //       cy.switchWallet(bidderWalletName);
+  //       cy.addNewTokensFound();
+  //       cy.getTokenAmount('IST').then(initialTokenValue => {
+  //         cy.placeBidByPrice({
+  //           fromAddress: bidderAddress,
+  //           giveAmount: '90IST',
+  //           price: 9,
+  //         });
+
+  //         cy.placeBidByDiscount({
+  //           fromAddress: bidderAddress,
+  //           giveAmount: '80IST',
+  //           discount: 10,
+  //         });
+
+  //         cy.placeBidByDiscount({
+  //           fromAddress: bidderAddress,
+  //           giveAmount: '150IST',
+  //           discount: 15,
+  //         });
+
+  //         cy.getTokenAmount('IST').then(tokenValue => {
+  //           expect(tokenValue).to.lessThan(initialTokenValue);
+  //         });
+  //       });
+  //     },
+  //   );
+
+  //   it('should verify vaults that are at a risk of being liquidated', () => {
+  //     cy.setOraclePrice(9.99);
+  //     cy.switchWallet('user1');
+  //     cy.contains(
+  //       /Please increase your collateral or repay your outstanding IST debt./,
+  //     );
+  //   });
+
+  //   it('should wait and verify vaults are being liquidated', () => {
+  //     cy.contains(/3 vaults are liquidating./, {
+  //       timeout: LIQUIDATING_TIMEOUT,
+  //     });
+  //   });
+
+  //   it('should verify the value of startPrice from the CLI successfully', () => {
+  //     const propertyName = 'book0.startPrice';
+  //     const expectedValue = '9.99 IST/ATOM';
+
+  //     cy.verifyAuctionData(propertyName, expectedValue);
+  //   });
+
+  //   it('should verify the value of startProceedsGoal from the CLI successfully', () => {
+  //     const propertyName = 'book0.startProceedsGoal';
+  //     const expectedValue = '309.54 IST';
+
+  //     cy.verifyAuctionData(propertyName, expectedValue);
+  //   });
+
+  //   it('should verify the value of startCollateral from the CLI successfully', () => {
+  //     const propertyName = 'book0.startCollateral';
+  //     const expectedValue = '45 ATOM';
+
+  //     cy.verifyAuctionData(propertyName, expectedValue);
+  //   });
+
+  //   it('should verify the value of collateralAvailable from the CLI successfully', () => {
+  //     const propertyName = 'book0.collateralAvailable';
+  //     const expectedValue = '45 ATOM';
+
+  //     cy.verifyAuctionData(propertyName, expectedValue);
+  //   });
+
+  //   // Tests ran fine locally but failed in CI. Updating a3p container replicated failure locally. Tests pass with older container version.
+  //   // UNTIL: a3p container compatibility is resolved.
+  //   it(
+  //     'should wait and verify vaults are liquidated',
+  //     {
+  //       defaultCommandTimeout: DEFAULT_TIMEOUT,
+  //       taskTimeout: DEFAULT_TASK_TIMEOUT,
+  //     },
+  //     () => {
+  //       cy.skipWhen(AGORIC_NET === networks.LOCAL);
+
+  //       cy.contains(/Collateral left to claim/, {
+  //         timeout: LIQUIDATED_TIMEOUT,
+  //       });
+  //       cy.contains(/3.42 ATOM/);
+  //       cy.contains(/3.07 ATOM/);
+  //       cy.contains(/2.84 ATOM/);
+  //     },
+  //   );
+
+  //   it('should verify the value of collateralAvailable from the CLI successfully', () => {
+  //     cy.skipWhen(AGORIC_NET === networks.LOCAL);
+
+  //     const propertyName = 'book0.collateralAvailable';
+  //     const expectedValue = '9.659302 ATOM';
+
+  //     cy.verifyAuctionData(propertyName, expectedValue);
+  //   });
+
+  //   it(
+  //     'should claim collateral from all vaults successfully',
+  //     {
+  //       defaultCommandTimeout: DEFAULT_TIMEOUT,
+  //       taskTimeout: DEFAULT_TASK_TIMEOUT,
+  //     },
+  //     () => {
+  //       cy.skipWhen(AGORIC_NET === networks.LOCAL);
+
+  //       cy.get('span:contains("Click to claim collateral")').then(elements => {
+  //         expect(elements.length).to.be.at.least(3);
+  //         elements.slice(0, 3).each((index, element) => {
+  //           cy.wrap(element).click();
+  //           cy.contains('button', 'Close Out Vault').click();
+  //           cy.acceptAccess().then(taskCompleted => {
+  //             expect(taskCompleted).to.be.true;
+  //             cy.contains('button', 'Close Out Vault').should('not.exist');
+  //           });
+  //         });
+  //       });
+  //     },
+  //   );
+
+  //   it('should set ATOM price back to 12.34', () => {
+  //     cy.skipWhen(AGORIC_NET === networks.LOCAL);
+  //     cy.setOraclePrice(12.34);
+  //   });
+
+  //   it('should setup the web wallet and cancel the 150IST bid', () => {
+  //     cy.skipWhen(AGORIC_NET === networks.LOCAL);
+
+  //     cy.switchWallet(bidderWalletName);
+
+  //     cy.visit(webWalletURL);
+
+  //     cy.acceptAccess().then(taskCompleted => {
+  //       expect(taskCompleted).to.be.true;
+  //     });
+
+  //     cy.visit(`${webWalletURL}/wallet/`);
+
+  //     cy.get('input[type="checkbox"]').check();
+  //     cy.contains('Proceed').click();
+  //     cy.get('button[aria-label="Settings"]').click();
+
+  //     cy.contains('div', 'Mainnet').click();
+  //     cy.contains('li', 'Emerynet').click();
+  //     cy.contains('button', 'Connect').click();
+
+  //     cy.acceptAccess().then(taskCompleted => {
+  //       expect(taskCompleted).to.be.true;
+  //     });
+
+  //     cy.reload();
+
+  //     cy.acceptAccess().then(taskCompleted => {
+  //       expect(taskCompleted).to.be.true;
+  //     });
+
+  //     cy.get('span')
+  //       .contains('ATOM', { timeout: DEFAULT_TIMEOUT })
+  //       .should('exist');
+  //     cy.get('span')
+  //       .contains('BLD', { timeout: DEFAULT_TIMEOUT })
+  //       .should('exist');
+
+  //     // Verify completely filled bids
+  //     cy.contains('90.00 IST', { timeout: DEFAULT_TIMEOUT }).should(
+  //       'not.exist',
+  //     );
+  //     cy.contains('80.00 IST', { timeout: DEFAULT_TIMEOUT }).should(
+  //       'not.exist',
+  //     );
+  //     // Verify 150 IST Bid to exist
+  //     cy.contains('150.00 IST', { timeout: DEFAULT_TIMEOUT }).should('exist');
+
+  //     cy.getTokenAmount('IST').then(initialTokenValue => {
+  //       cy.contains('Exit').click();
+  //       cy.acceptAccess().then(taskCompleted => {
+  //         expect(taskCompleted).to.be.true;
+  //       });
+  //       cy.contains('Accepted', { timeout: DEFAULT_TIMEOUT }).should('exist');
+  //       cy.getTokenAmount('IST').then(tokenValue => {
+  //         expect(tokenValue).to.greaterThan(initialTokenValue);
+  //       });
+  //     });
+  //   });
+  // });
 });

--- a/test/e2e/specs/liquidation.spec.js
+++ b/test/e2e/specs/liquidation.spec.js
@@ -25,555 +25,549 @@ describe('Wallet App Test Cases', () => {
   const gov2Address = currentConfig.gov2Address;
   const econGovURL = currentConfig.econGovURL;
 
-  it("DUMMY", () => {
-    cy.log(`AGORIC ${AGORIC_NET}......USER1ADDR:${user1Address}`)
-    cy.log(`BIDDER ${bidderAddress} Gov1ADDR: ${gov1Address} gov2ADDr: ${gov2Address}`)
-    cy.wait(2 * 60 * 1000)
-  })
-
-  // context('Setting up accounts', () => {
-  //   // Using exports from the synthetic-chain lib instead of hardcoding mnemonics UNTIL https://github.com/Agoric/agoric-3-proposals/issues/154
-  //   it('should set up bidder wallet', () => {
-  //     cy.skipWhen(AGORIC_NET === networks.LOCAL);
-
-  //     cy.setupWallet({
-  //       secretWords: bidderMnemonic,
-  //       walletName: bidderWalletName,
-  //     }).then(taskCompleted => {
-  //       expect(taskCompleted).to.be.true;
-  //     });
-  //   });
-
-  //   it('should set up user1 wallet', () => {
-  //     cy.setupWallet({
-  //       secretWords: user1Mnemonic,
-  //       walletName: 'user1',
-  //     }).then(taskCompleted => {
-  //       expect(taskCompleted).to.be.true;
-  //     });
-  //   });
-
-  //   it('should set up gov1 wallet', () => {
-  //     cy.skipWhen(AGORIC_NET === networks.EMERYNET);
-
-  //     cy.setupWallet({
-  //       secretWords: mnemonics.gov1,
-  //       walletName: 'gov1',
-  //     }).then(taskCompleted => {
-  //       expect(taskCompleted).to.be.true;
-  //     });
-  //   });
-
-  //   it('should set up gov2 wallet', () => {
-  //     cy.skipWhen(AGORIC_NET === networks.EMERYNET);
-
-  //     cy.setupWallet({
-  //       secretWords: mnemonics.gov2,
-  //       walletName: 'gov2',
-  //     }).then(taskCompleted => {
-  //       expect(taskCompleted).to.be.true;
-  //     });
-  //   });
-  // });
-
-  // context('Adjusting manager params from econ-gov', () => {
-  //   it('should connect with chain and wallet', () => {
-  //     cy.skipWhen(AGORIC_NET === networks.EMERYNET);
-
-  //     cy.visit(econGovURL);
-  //     cy.acceptAccess().then(taskCompleted => {
-  //       expect(taskCompleted).to.be.true;
-  //     });
-  //   });
-  //   it('should allow gov2 to create a proposal', () => {
-  //     cy.skipWhen(AGORIC_NET === networks.EMERYNET);
-
-  //     cy.visit(econGovURL);
-  //     cy.acceptAccess();
-
-  //     cy.get('button').contains('Vaults').click();
-  //     cy.get('button').contains('Select Manager').click();
-  //     cy.get('button').contains('manager0').click();
-
-  //     cy.get('label')
-  //       .contains('LiquidationMargin')
-  //       .parent()
-  //       .within(() => {
-  //         cy.get('input').clear();
-  //         cy.get('input').type('150');
-  //       });
-
-  //     cy.get('label')
-  //       .contains('LiquidationPadding')
-  //       .parent()
-  //       .within(() => {
-  //         cy.get('input').clear();
-  //         cy.get('input').type('25');
-  //       });
-
-  //     cy.get('label')
-  //       .contains('LiquidationPenalty')
-  //       .parent()
-  //       .within(() => {
-  //         cy.get('input').clear();
-  //         cy.get('input').type('1');
-  //       });
-
-  //     cy.get('label')
-  //       .contains('StabilityFee')
-  //       .parent()
-  //       .within(() => {
-  //         cy.get('input').clear();
-  //         cy.get('input').type('1');
-  //       });
-
-  //     cy.get('label')
-  //       .contains('MintFee')
-  //       .parent()
-  //       .within(() => {
-  //         cy.get('input').clear();
-  //         cy.get('input').type('0.5');
-  //       });
-
-  //     cy.get('label')
-  //       .contains('Minutes until close of vote')
-  //       .parent()
-  //       .within(() => {
-  //         cy.get('input').clear();
-  //         cy.get('input').type(1);
-  //       });
-  //     cy.get('[value="Propose Parameter Change"]').click();
-
-  //     cy.confirmTransaction();
-  //     cy.get('p')
-  //       .contains('sent')
-  //       .should('be.visible')
-  //       .then(() => {
-  //         startTime = Date.now();
-  //       });
-  //   });
-
-  //   it('should allow gov2 to vote on the proposal', () => {
-  //     cy.skipWhen(AGORIC_NET === networks.EMERYNET);
-  //     cy.visit(econGovURL);
-
-  //     cy.get('button').contains('Vote').click();
-  //     cy.get('p').contains('YES').click();
-  //     cy.get('input:enabled[value="Submit Vote"]').click();
-
-  //     cy.confirmTransaction();
-  //     cy.get('p').contains('sent').should('be.visible');
-  //   });
-
-  //   it('should allow gov1 to vote on the proposal', () => {
-  //     cy.skipWhen(AGORIC_NET === networks.EMERYNET);
-
-  //     cy.switchWallet('gov1');
-  //     cy.visit(econGovURL);
-
-  //     cy.get('button').contains('Vote').click();
-  //     cy.get('p').contains('YES').click();
-  //     cy.get('input:enabled[value="Submit Vote"]').click();
-
-  //     cy.confirmTransaction();
-  //     cy.get('p').contains('sent').should('be.visible');
-  //   });
-
-  //   it('should wait for proposal to pass', () => {
-  //     cy.skipWhen(AGORIC_NET === networks.EMERYNET);
-
-  //     cy.wait(MINUTE_MS - Date.now() + startTime);
-  //     cy.visit(econGovURL);
-
-  //     cy.get('button').contains('History').click();
-
-  //     cy.get('code')
-  //       .contains('VaultFactory - ATOM')
-  //       .parent()
-  //       .parent()
-  //       .parent()
-  //       .within(() => {
-  //         cy.get('span').contains('Change Accepted').should('be.visible');
-  //       });
-  //   });
-  // });
-
-  // context('Adjusting auction params from econ-gov', () => {
-  //   it('should allow gov1 to create a proposal', () => {
-  //     cy.skipWhen(AGORIC_NET === networks.EMERYNET);
-
-  //     cy.visit(econGovURL);
-
-  //     cy.get('button').contains('Vaults').click();
-  //     cy.get('button').contains('Change Manager Params').click();
-  //     cy.get('button').contains('Change Auctioneer Params').click();
-
-  //     cy.get('label')
-  //       .contains('StartingRate')
-  //       .parent()
-  //       .within(() => {
-  //         cy.get('input').clear();
-  //         cy.get('input').type('10500');
-  //       });
-
-  //     cy.get('label')
-  //       .contains('LowestRate')
-  //       .parent()
-  //       .within(() => {
-  //         cy.get('input').clear();
-  //         cy.get('input').type('6500');
-  //       });
-
-  //     cy.get('label')
-  //       .contains('DiscountStep')
-  //       .parent()
-  //       .within(() => {
-  //         cy.get('input').clear();
-  //         cy.get('input').type('500');
-  //       });
-
-  //     cy.get('label')
-  //       .contains('AuctionStartDelay')
-  //       .parent()
-  //       .within(() => {
-  //         cy.get('input').clear();
-  //         cy.get('input').type('2');
-  //       });
-
-  //     cy.get('label')
-  //       .contains('Minutes until close of vote')
-  //       .parent()
-  //       .within(() => {
-  //         cy.get('input').clear();
-  //         cy.get('input').type(1);
-  //       });
-  //     cy.get('[value="Propose Parameter Change"]').click();
-
-  //     cy.confirmTransaction();
-  //     cy.get('p')
-  //       .contains('sent')
-  //       .should('be.visible')
-  //       .then(() => {
-  //         startTime = Date.now();
-  //       });
-  //   });
-
-  //   it('should allow gov1 to vote on the proposal', () => {
-  //     cy.skipWhen(AGORIC_NET === networks.EMERYNET);
-
-  //     cy.visit(econGovURL);
-
-  //     cy.get('button').contains('Vote').click();
-  //     cy.get('p').contains('YES').click();
-  //     cy.get('input:enabled[value="Submit Vote"]').click();
-
-  //     cy.confirmTransaction();
-  //     cy.get('p').contains('sent').should('be.visible');
-  //   });
-
-  //   it('should allow gov2 to vote on the proposal', () => {
-  //     cy.skipWhen(AGORIC_NET === networks.EMERYNET);
-
-  //     cy.switchWallet('gov2');
-  //     cy.visit(econGovURL);
-
-  //     cy.get('button').contains('Vote').click();
-  //     cy.get('p').contains('YES').click();
-  //     cy.get('input:enabled[value="Submit Vote"]').click();
-
-  //     cy.confirmTransaction();
-  //     cy.get('p').contains('sent').should('be.visible');
-  //   });
-
-  //   it('should wait for proposal to pass', () => {
-  //     cy.skipWhen(AGORIC_NET === networks.EMERYNET);
-
-  //     cy.wait(MINUTE_MS - Date.now() + startTime);
-  //     cy.visit(econGovURL);
-
-  //     cy.get('button').contains('History').click();
-
-  //     cy.get('code')
-  //       .contains('VaultFactory - ATOM')
-  //       .parent()
-  //       .parent()
-  //       .parent()
-  //       .within(() => {
-  //         cy.get('span').contains('Change Accepted').should('be.visible');
-  //       });
-
-  //     cy.switchWallet('user1');
-  //   });
-  // });
-
-  // context('Creating vaults and changing ATOM price', () => {
-  //   it(
-  //     'should connect with the wallet',
-  //     {
-  //       defaultCommandTimeout: DEFAULT_TIMEOUT,
-  //       taskTimeout: DEFAULT_TASK_TIMEOUT,
-  //     },
-  //     () => {
-  //       cy.connectWithWallet();
-  //     },
-  //   );
-
-  //   it('should add all the keys successfully', () => {
-  //     cy.addKeys({
-  //       keyName: 'gov1',
-  //       mnemonic: gov1Mnemonic,
-  //       expectedAddress: gov1Address,
-  //     });
-  //     cy.addKeys({
-  //       keyName: 'gov2',
-  //       mnemonic: gov2Mnemonic,
-  //       expectedAddress: gov2Address,
-  //     });
-  //     cy.addKeys({
-  //       keyName: 'user1',
-  //       mnemonic: user1Mnemonic,
-  //       expectedAddress: user1Address,
-  //     });
-  //   });
-
-  //   it('should add the bidder key successfully', () => {
-  //     cy.skipWhen(AGORIC_NET === networks.LOCAL);
-  //     cy.addKeys({
-  //       keyName: 'bidder',
-  //       mnemonic: bidderMnemonic,
-  //       expectedAddress: bidderAddress,
-  //     });
-  //   });
-  //   it('should set ATOM price to 12.34', () => {
-  //     cy.setOraclePrice(12.34);
-  //   });
-
-  //   it('should create a vault minting 100 ISTs and giving 15 ATOMs as collateral', () => {
-  //     cy.createVault({ wantMinted: 100, giveCollateral: 15, userKey: 'user1' });
-  //   });
-
-  //   it('should create a vault minting 103 ISTs and giving 15 ATOMs as collateral', () => {
-  //     cy.createVault({ wantMinted: 103, giveCollateral: 15, userKey: 'user1' });
-  //   });
-
-  //   it('should create a vault minting 105 ISTs and giving 15 ATOMs as collateral', () => {
-  //     cy.createVault({ wantMinted: 105, giveCollateral: 15, userKey: 'user1' });
-  //   });
-
-  //   it(
-  //     'should check for the existence of vaults on the UI',
-  //     {
-  //       defaultCommandTimeout: DEFAULT_TIMEOUT,
-  //       taskTimeout: DEFAULT_TASK_TIMEOUT,
-  //     },
-  //     () => {
-  //       cy.contains('button', 'Back to vaults').click();
-  //       cy.scrollTo('bottom', { ensureScrollable: false });
-  //       cy.contains('100.50 IST').should('exist');
-  //       cy.contains('103.51 IST').should('exist');
-  //       cy.contains('105.52 IST').should('exist');
-  //     },
-  //   );
-  // });
-
-  // context('Place bids and make all vaults enter liquidation', () => {
-  //   it('should create a vault minting 400 ISTs and giving 80 ATOMs as collateral', () => {
-  //     cy.skipWhen(AGORIC_NET === networks.EMERYNET);
-  //     cy.createVault({ wantMinted: 400, giveCollateral: 80, userKey: 'gov1' });
-  //   });
-
-  //   it(
-  //     'should place bids from the CLI successfully',
-  //     {
-  //       defaultCommandTimeout: DEFAULT_TIMEOUT,
-  //       taskTimeout: DEFAULT_TASK_TIMEOUT,
-  //     },
-  //     () => {
-  //       cy.switchWallet(bidderWalletName);
-  //       cy.addNewTokensFound();
-  //       cy.getTokenAmount('IST').then(initialTokenValue => {
-  //         cy.placeBidByPrice({
-  //           fromAddress: bidderAddress,
-  //           giveAmount: '90IST',
-  //           price: 9,
-  //         });
-
-  //         cy.placeBidByDiscount({
-  //           fromAddress: bidderAddress,
-  //           giveAmount: '80IST',
-  //           discount: 10,
-  //         });
-
-  //         cy.placeBidByDiscount({
-  //           fromAddress: bidderAddress,
-  //           giveAmount: '150IST',
-  //           discount: 15,
-  //         });
-
-  //         cy.getTokenAmount('IST').then(tokenValue => {
-  //           expect(tokenValue).to.lessThan(initialTokenValue);
-  //         });
-  //       });
-  //     },
-  //   );
-
-  //   it('should verify vaults that are at a risk of being liquidated', () => {
-  //     cy.setOraclePrice(9.99);
-  //     cy.switchWallet('user1');
-  //     cy.contains(
-  //       /Please increase your collateral or repay your outstanding IST debt./,
-  //     );
-  //   });
-
-  //   it('should wait and verify vaults are being liquidated', () => {
-  //     cy.contains(/3 vaults are liquidating./, {
-  //       timeout: LIQUIDATING_TIMEOUT,
-  //     });
-  //   });
-
-  //   it('should verify the value of startPrice from the CLI successfully', () => {
-  //     const propertyName = 'book0.startPrice';
-  //     const expectedValue = '9.99 IST/ATOM';
-
-  //     cy.verifyAuctionData(propertyName, expectedValue);
-  //   });
-
-  //   it('should verify the value of startProceedsGoal from the CLI successfully', () => {
-  //     const propertyName = 'book0.startProceedsGoal';
-  //     const expectedValue = '309.54 IST';
-
-  //     cy.verifyAuctionData(propertyName, expectedValue);
-  //   });
-
-  //   it('should verify the value of startCollateral from the CLI successfully', () => {
-  //     const propertyName = 'book0.startCollateral';
-  //     const expectedValue = '45 ATOM';
-
-  //     cy.verifyAuctionData(propertyName, expectedValue);
-  //   });
-
-  //   it('should verify the value of collateralAvailable from the CLI successfully', () => {
-  //     const propertyName = 'book0.collateralAvailable';
-  //     const expectedValue = '45 ATOM';
-
-  //     cy.verifyAuctionData(propertyName, expectedValue);
-  //   });
-
-  //   // Tests ran fine locally but failed in CI. Updating a3p container replicated failure locally. Tests pass with older container version.
-  //   // UNTIL: a3p container compatibility is resolved.
-  //   it(
-  //     'should wait and verify vaults are liquidated',
-  //     {
-  //       defaultCommandTimeout: DEFAULT_TIMEOUT,
-  //       taskTimeout: DEFAULT_TASK_TIMEOUT,
-  //     },
-  //     () => {
-  //       cy.skipWhen(AGORIC_NET === networks.LOCAL);
-
-  //       cy.contains(/Collateral left to claim/, {
-  //         timeout: LIQUIDATED_TIMEOUT,
-  //       });
-  //       cy.contains(/3.42 ATOM/);
-  //       cy.contains(/3.07 ATOM/);
-  //       cy.contains(/2.84 ATOM/);
-  //     },
-  //   );
-
-  //   it('should verify the value of collateralAvailable from the CLI successfully', () => {
-  //     cy.skipWhen(AGORIC_NET === networks.LOCAL);
-
-  //     const propertyName = 'book0.collateralAvailable';
-  //     const expectedValue = '9.659302 ATOM';
-
-  //     cy.verifyAuctionData(propertyName, expectedValue);
-  //   });
-
-  //   it(
-  //     'should claim collateral from all vaults successfully',
-  //     {
-  //       defaultCommandTimeout: DEFAULT_TIMEOUT,
-  //       taskTimeout: DEFAULT_TASK_TIMEOUT,
-  //     },
-  //     () => {
-  //       cy.skipWhen(AGORIC_NET === networks.LOCAL);
-
-  //       cy.get('span:contains("Click to claim collateral")').then(elements => {
-  //         expect(elements.length).to.be.at.least(3);
-  //         elements.slice(0, 3).each((index, element) => {
-  //           cy.wrap(element).click();
-  //           cy.contains('button', 'Close Out Vault').click();
-  //           cy.acceptAccess().then(taskCompleted => {
-  //             expect(taskCompleted).to.be.true;
-  //             cy.contains('button', 'Close Out Vault').should('not.exist');
-  //           });
-  //         });
-  //       });
-  //     },
-  //   );
-
-  //   it('should set ATOM price back to 12.34', () => {
-  //     cy.skipWhen(AGORIC_NET === networks.LOCAL);
-  //     cy.setOraclePrice(12.34);
-  //   });
-
-  //   it('should setup the web wallet and cancel the 150IST bid', () => {
-  //     cy.skipWhen(AGORIC_NET === networks.LOCAL);
-
-  //     cy.switchWallet(bidderWalletName);
-
-  //     cy.visit(webWalletURL);
-
-  //     cy.acceptAccess().then(taskCompleted => {
-  //       expect(taskCompleted).to.be.true;
-  //     });
-
-  //     cy.visit(`${webWalletURL}/wallet/`);
-
-  //     cy.get('input[type="checkbox"]').check();
-  //     cy.contains('Proceed').click();
-  //     cy.get('button[aria-label="Settings"]').click();
-
-  //     cy.contains('div', 'Mainnet').click();
-  //     cy.contains('li', 'Emerynet').click();
-  //     cy.contains('button', 'Connect').click();
-
-  //     cy.acceptAccess().then(taskCompleted => {
-  //       expect(taskCompleted).to.be.true;
-  //     });
-
-  //     cy.reload();
-
-  //     cy.acceptAccess().then(taskCompleted => {
-  //       expect(taskCompleted).to.be.true;
-  //     });
-
-  //     cy.get('span')
-  //       .contains('ATOM', { timeout: DEFAULT_TIMEOUT })
-  //       .should('exist');
-  //     cy.get('span')
-  //       .contains('BLD', { timeout: DEFAULT_TIMEOUT })
-  //       .should('exist');
-
-  //     // Verify completely filled bids
-  //     cy.contains('90.00 IST', { timeout: DEFAULT_TIMEOUT }).should(
-  //       'not.exist',
-  //     );
-  //     cy.contains('80.00 IST', { timeout: DEFAULT_TIMEOUT }).should(
-  //       'not.exist',
-  //     );
-  //     // Verify 150 IST Bid to exist
-  //     cy.contains('150.00 IST', { timeout: DEFAULT_TIMEOUT }).should('exist');
-
-  //     cy.getTokenAmount('IST').then(initialTokenValue => {
-  //       cy.contains('Exit').click();
-  //       cy.acceptAccess().then(taskCompleted => {
-  //         expect(taskCompleted).to.be.true;
-  //       });
-  //       cy.contains('Accepted', { timeout: DEFAULT_TIMEOUT }).should('exist');
-  //       cy.getTokenAmount('IST').then(tokenValue => {
-  //         expect(tokenValue).to.greaterThan(initialTokenValue);
-  //       });
-  //     });
-  //   });
-  // });
+  context('Setting up accounts', () => {
+    // Using exports from the synthetic-chain lib instead of hardcoding mnemonics UNTIL https://github.com/Agoric/agoric-3-proposals/issues/154
+    it('should set up bidder wallet', () => {
+      cy.skipWhen(AGORIC_NET === networks.LOCAL);
+
+      cy.setupWallet({
+        secretWords: bidderMnemonic,
+        walletName: bidderWalletName,
+      }).then(taskCompleted => {
+        expect(taskCompleted).to.be.true;
+      });
+    });
+
+    it('should set up user1 wallet', () => {
+      cy.setupWallet({
+        secretWords: user1Mnemonic,
+        walletName: 'user1',
+      }).then(taskCompleted => {
+        expect(taskCompleted).to.be.true;
+      });
+    });
+
+    it('should set up gov1 wallet', () => {
+      cy.skipWhen(AGORIC_NET === networks.EMERYNET);
+
+      cy.setupWallet({
+        secretWords: mnemonics.gov1,
+        walletName: 'gov1',
+      }).then(taskCompleted => {
+        expect(taskCompleted).to.be.true;
+      });
+    });
+
+    it('should set up gov2 wallet', () => {
+      cy.skipWhen(AGORIC_NET === networks.EMERYNET);
+
+      cy.setupWallet({
+        secretWords: mnemonics.gov2,
+        walletName: 'gov2',
+      }).then(taskCompleted => {
+        expect(taskCompleted).to.be.true;
+      });
+    });
+  });
+
+  context('Adjusting manager params from econ-gov', () => {
+    it('should connect with chain and wallet', () => {
+      cy.skipWhen(AGORIC_NET === networks.EMERYNET);
+
+      cy.visit(econGovURL);
+      cy.acceptAccess().then(taskCompleted => {
+        expect(taskCompleted).to.be.true;
+      });
+    });
+    it('should allow gov2 to create a proposal', () => {
+      cy.skipWhen(AGORIC_NET === networks.EMERYNET);
+
+      cy.visit(econGovURL);
+      cy.acceptAccess();
+
+      cy.get('button').contains('Vaults').click();
+      cy.get('button').contains('Select Manager').click();
+      cy.get('button').contains('manager0').click();
+
+      cy.get('label')
+        .contains('LiquidationMargin')
+        .parent()
+        .within(() => {
+          cy.get('input').clear();
+          cy.get('input').type('150');
+        });
+
+      cy.get('label')
+        .contains('LiquidationPadding')
+        .parent()
+        .within(() => {
+          cy.get('input').clear();
+          cy.get('input').type('25');
+        });
+
+      cy.get('label')
+        .contains('LiquidationPenalty')
+        .parent()
+        .within(() => {
+          cy.get('input').clear();
+          cy.get('input').type('1');
+        });
+
+      cy.get('label')
+        .contains('StabilityFee')
+        .parent()
+        .within(() => {
+          cy.get('input').clear();
+          cy.get('input').type('1');
+        });
+
+      cy.get('label')
+        .contains('MintFee')
+        .parent()
+        .within(() => {
+          cy.get('input').clear();
+          cy.get('input').type('0.5');
+        });
+
+      cy.get('label')
+        .contains('Minutes until close of vote')
+        .parent()
+        .within(() => {
+          cy.get('input').clear();
+          cy.get('input').type(1);
+        });
+      cy.get('[value="Propose Parameter Change"]').click();
+
+      cy.confirmTransaction();
+      cy.get('p')
+        .contains('sent')
+        .should('be.visible')
+        .then(() => {
+          startTime = Date.now();
+        });
+    });
+
+    it('should allow gov2 to vote on the proposal', () => {
+      cy.skipWhen(AGORIC_NET === networks.EMERYNET);
+      cy.visit(econGovURL);
+
+      cy.get('button').contains('Vote').click();
+      cy.get('p').contains('YES').click();
+      cy.get('input:enabled[value="Submit Vote"]').click();
+
+      cy.confirmTransaction();
+      cy.get('p').contains('sent').should('be.visible');
+    });
+
+    it('should allow gov1 to vote on the proposal', () => {
+      cy.skipWhen(AGORIC_NET === networks.EMERYNET);
+
+      cy.switchWallet('gov1');
+      cy.visit(econGovURL);
+
+      cy.get('button').contains('Vote').click();
+      cy.get('p').contains('YES').click();
+      cy.get('input:enabled[value="Submit Vote"]').click();
+
+      cy.confirmTransaction();
+      cy.get('p').contains('sent').should('be.visible');
+    });
+
+    it('should wait for proposal to pass', () => {
+      cy.skipWhen(AGORIC_NET === networks.EMERYNET);
+
+      cy.wait(MINUTE_MS - Date.now() + startTime);
+      cy.visit(econGovURL);
+
+      cy.get('button').contains('History').click();
+
+      cy.get('code')
+        .contains('VaultFactory - ATOM')
+        .parent()
+        .parent()
+        .parent()
+        .within(() => {
+          cy.get('span').contains('Change Accepted').should('be.visible');
+        });
+    });
+  });
+
+  context('Adjusting auction params from econ-gov', () => {
+    it('should allow gov1 to create a proposal', () => {
+      cy.skipWhen(AGORIC_NET === networks.EMERYNET);
+
+      cy.visit(econGovURL);
+
+      cy.get('button').contains('Vaults').click();
+      cy.get('button').contains('Change Manager Params').click();
+      cy.get('button').contains('Change Auctioneer Params').click();
+
+      cy.get('label')
+        .contains('StartingRate')
+        .parent()
+        .within(() => {
+          cy.get('input').clear();
+          cy.get('input').type('10500');
+        });
+
+      cy.get('label')
+        .contains('LowestRate')
+        .parent()
+        .within(() => {
+          cy.get('input').clear();
+          cy.get('input').type('6500');
+        });
+
+      cy.get('label')
+        .contains('DiscountStep')
+        .parent()
+        .within(() => {
+          cy.get('input').clear();
+          cy.get('input').type('500');
+        });
+
+      cy.get('label')
+        .contains('AuctionStartDelay')
+        .parent()
+        .within(() => {
+          cy.get('input').clear();
+          cy.get('input').type('2');
+        });
+
+      cy.get('label')
+        .contains('Minutes until close of vote')
+        .parent()
+        .within(() => {
+          cy.get('input').clear();
+          cy.get('input').type(1);
+        });
+      cy.get('[value="Propose Parameter Change"]').click();
+
+      cy.confirmTransaction();
+      cy.get('p')
+        .contains('sent')
+        .should('be.visible')
+        .then(() => {
+          startTime = Date.now();
+        });
+    });
+
+    it('should allow gov1 to vote on the proposal', () => {
+      cy.skipWhen(AGORIC_NET === networks.EMERYNET);
+
+      cy.visit(econGovURL);
+
+      cy.get('button').contains('Vote').click();
+      cy.get('p').contains('YES').click();
+      cy.get('input:enabled[value="Submit Vote"]').click();
+
+      cy.confirmTransaction();
+      cy.get('p').contains('sent').should('be.visible');
+    });
+
+    it('should allow gov2 to vote on the proposal', () => {
+      cy.skipWhen(AGORIC_NET === networks.EMERYNET);
+
+      cy.switchWallet('gov2');
+      cy.visit(econGovURL);
+
+      cy.get('button').contains('Vote').click();
+      cy.get('p').contains('YES').click();
+      cy.get('input:enabled[value="Submit Vote"]').click();
+
+      cy.confirmTransaction();
+      cy.get('p').contains('sent').should('be.visible');
+    });
+
+    it('should wait for proposal to pass', () => {
+      cy.skipWhen(AGORIC_NET === networks.EMERYNET);
+
+      cy.wait(MINUTE_MS - Date.now() + startTime);
+      cy.visit(econGovURL);
+
+      cy.get('button').contains('History').click();
+
+      cy.get('code')
+        .contains('VaultFactory - ATOM')
+        .parent()
+        .parent()
+        .parent()
+        .within(() => {
+          cy.get('span').contains('Change Accepted').should('be.visible');
+        });
+
+      cy.switchWallet('user1');
+    });
+  });
+
+  context('Creating vaults and changing ATOM price', () => {
+    it(
+      'should connect with the wallet',
+      {
+        defaultCommandTimeout: DEFAULT_TIMEOUT,
+        taskTimeout: DEFAULT_TASK_TIMEOUT,
+      },
+      () => {
+        cy.connectWithWallet();
+      },
+    );
+
+    it('should add all the keys successfully', () => {
+      cy.addKeys({
+        keyName: 'gov1',
+        mnemonic: gov1Mnemonic,
+        expectedAddress: gov1Address,
+      });
+      cy.addKeys({
+        keyName: 'gov2',
+        mnemonic: gov2Mnemonic,
+        expectedAddress: gov2Address,
+      });
+      cy.addKeys({
+        keyName: 'user1',
+        mnemonic: user1Mnemonic,
+        expectedAddress: user1Address,
+      });
+    });
+
+    it('should add the bidder key successfully', () => {
+      cy.skipWhen(AGORIC_NET === networks.LOCAL);
+      cy.addKeys({
+        keyName: 'bidder',
+        mnemonic: bidderMnemonic,
+        expectedAddress: bidderAddress,
+      });
+    });
+    it('should set ATOM price to 12.34', () => {
+      cy.setOraclePrice(12.34);
+    });
+
+    it('should create a vault minting 100 ISTs and giving 15 ATOMs as collateral', () => {
+      cy.createVault({ wantMinted: 100, giveCollateral: 15, userKey: 'user1' });
+    });
+
+    it('should create a vault minting 103 ISTs and giving 15 ATOMs as collateral', () => {
+      cy.createVault({ wantMinted: 103, giveCollateral: 15, userKey: 'user1' });
+    });
+
+    it('should create a vault minting 105 ISTs and giving 15 ATOMs as collateral', () => {
+      cy.createVault({ wantMinted: 105, giveCollateral: 15, userKey: 'user1' });
+    });
+
+    it(
+      'should check for the existence of vaults on the UI',
+      {
+        defaultCommandTimeout: DEFAULT_TIMEOUT,
+        taskTimeout: DEFAULT_TASK_TIMEOUT,
+      },
+      () => {
+        cy.contains('button', 'Back to vaults').click();
+        cy.scrollTo('bottom', { ensureScrollable: false });
+        cy.contains('100.50 IST').should('exist');
+        cy.contains('103.51 IST').should('exist');
+        cy.contains('105.52 IST').should('exist');
+      },
+    );
+  });
+
+  context('Place bids and make all vaults enter liquidation', () => {
+    it('should create a vault minting 400 ISTs and giving 80 ATOMs as collateral', () => {
+      cy.skipWhen(AGORIC_NET === networks.EMERYNET);
+      cy.createVault({ wantMinted: 400, giveCollateral: 80, userKey: 'gov1' });
+    });
+
+    it(
+      'should place bids from the CLI successfully',
+      {
+        defaultCommandTimeout: DEFAULT_TIMEOUT,
+        taskTimeout: DEFAULT_TASK_TIMEOUT,
+      },
+      () => {
+        cy.switchWallet(bidderWalletName);
+        cy.addNewTokensFound();
+        cy.getTokenAmount('IST').then(initialTokenValue => {
+          cy.placeBidByPrice({
+            fromAddress: bidderAddress,
+            giveAmount: '90IST',
+            price: 9,
+          });
+
+          cy.placeBidByDiscount({
+            fromAddress: bidderAddress,
+            giveAmount: '80IST',
+            discount: 10,
+          });
+
+          cy.placeBidByDiscount({
+            fromAddress: bidderAddress,
+            giveAmount: '150IST',
+            discount: 15,
+          });
+
+          cy.getTokenAmount('IST').then(tokenValue => {
+            expect(tokenValue).to.lessThan(initialTokenValue);
+          });
+        });
+      },
+    );
+
+    it('should verify vaults that are at a risk of being liquidated', () => {
+      cy.setOraclePrice(9.99);
+      cy.switchWallet('user1');
+      cy.contains(
+        /Please increase your collateral or repay your outstanding IST debt./,
+      );
+    });
+
+    it('should wait and verify vaults are being liquidated', () => {
+      cy.contains(/3 vaults are liquidating./, {
+        timeout: LIQUIDATING_TIMEOUT,
+      });
+    });
+
+    it('should verify the value of startPrice from the CLI successfully', () => {
+      const propertyName = 'book0.startPrice';
+      const expectedValue = '9.99 IST/ATOM';
+
+      cy.verifyAuctionData(propertyName, expectedValue);
+    });
+
+    it('should verify the value of startProceedsGoal from the CLI successfully', () => {
+      const propertyName = 'book0.startProceedsGoal';
+      const expectedValue = '309.54 IST';
+
+      cy.verifyAuctionData(propertyName, expectedValue);
+    });
+
+    it('should verify the value of startCollateral from the CLI successfully', () => {
+      const propertyName = 'book0.startCollateral';
+      const expectedValue = '45 ATOM';
+
+      cy.verifyAuctionData(propertyName, expectedValue);
+    });
+
+    it('should verify the value of collateralAvailable from the CLI successfully', () => {
+      const propertyName = 'book0.collateralAvailable';
+      const expectedValue = '45 ATOM';
+
+      cy.verifyAuctionData(propertyName, expectedValue);
+    });
+
+    // Tests ran fine locally but failed in CI. Updating a3p container replicated failure locally. Tests pass with older container version.
+    // UNTIL: a3p container compatibility is resolved.
+    it(
+      'should wait and verify vaults are liquidated',
+      {
+        defaultCommandTimeout: DEFAULT_TIMEOUT,
+        taskTimeout: DEFAULT_TASK_TIMEOUT,
+      },
+      () => {
+        cy.skipWhen(AGORIC_NET === networks.LOCAL);
+
+        cy.contains(/Collateral left to claim/, {
+          timeout: LIQUIDATED_TIMEOUT,
+        });
+        cy.contains(/3.42 ATOM/);
+        cy.contains(/3.07 ATOM/);
+        cy.contains(/2.84 ATOM/);
+      },
+    );
+
+    it('should verify the value of collateralAvailable from the CLI successfully', () => {
+      cy.skipWhen(AGORIC_NET === networks.LOCAL);
+
+      const propertyName = 'book0.collateralAvailable';
+      const expectedValue = '9.659302 ATOM';
+
+      cy.verifyAuctionData(propertyName, expectedValue);
+    });
+
+    it(
+      'should claim collateral from all vaults successfully',
+      {
+        defaultCommandTimeout: DEFAULT_TIMEOUT,
+        taskTimeout: DEFAULT_TASK_TIMEOUT,
+      },
+      () => {
+        cy.skipWhen(AGORIC_NET === networks.LOCAL);
+
+        cy.get('span:contains("Click to claim collateral")').then(elements => {
+          expect(elements.length).to.be.at.least(3);
+          elements.slice(0, 3).each((index, element) => {
+            cy.wrap(element).click();
+            cy.contains('button', 'Close Out Vault').click();
+            cy.acceptAccess().then(taskCompleted => {
+              expect(taskCompleted).to.be.true;
+              cy.contains('button', 'Close Out Vault').should('not.exist');
+            });
+          });
+        });
+      },
+    );
+
+    it('should set ATOM price back to 12.34', () => {
+      cy.skipWhen(AGORIC_NET === networks.LOCAL);
+      cy.setOraclePrice(12.34);
+    });
+
+    it('should setup the web wallet and cancel the 150IST bid', () => {
+      cy.skipWhen(AGORIC_NET === networks.LOCAL);
+
+      cy.switchWallet(bidderWalletName);
+
+      cy.visit(webWalletURL);
+
+      cy.acceptAccess().then(taskCompleted => {
+        expect(taskCompleted).to.be.true;
+      });
+
+      cy.visit(`${webWalletURL}/wallet/`);
+
+      cy.get('input[type="checkbox"]').check();
+      cy.contains('Proceed').click();
+      cy.get('button[aria-label="Settings"]').click();
+
+      cy.contains('div', 'Mainnet').click();
+      cy.contains('li', 'Emerynet').click();
+      cy.contains('button', 'Connect').click();
+
+      cy.acceptAccess().then(taskCompleted => {
+        expect(taskCompleted).to.be.true;
+      });
+
+      cy.reload();
+
+      cy.acceptAccess().then(taskCompleted => {
+        expect(taskCompleted).to.be.true;
+      });
+
+      cy.get('span')
+        .contains('ATOM', { timeout: DEFAULT_TIMEOUT })
+        .should('exist');
+      cy.get('span')
+        .contains('BLD', { timeout: DEFAULT_TIMEOUT })
+        .should('exist');
+
+      // Verify completely filled bids
+      cy.contains('90.00 IST', { timeout: DEFAULT_TIMEOUT }).should(
+        'not.exist',
+      );
+      cy.contains('80.00 IST', { timeout: DEFAULT_TIMEOUT }).should(
+        'not.exist',
+      );
+      // Verify 150 IST Bid to exist
+      cy.contains('150.00 IST', { timeout: DEFAULT_TIMEOUT }).should('exist');
+
+      cy.getTokenAmount('IST').then(initialTokenValue => {
+        cy.contains('Exit').click();
+        cy.acceptAccess().then(taskCompleted => {
+          expect(taskCompleted).to.be.true;
+        });
+        cy.contains('Accepted', { timeout: DEFAULT_TIMEOUT }).should('exist');
+        cy.getTokenAmount('IST').then(tokenValue => {
+          expect(tokenValue).to.greaterThan(initialTokenValue);
+        });
+      });
+    });
+  });
 });


### PR DESCRIPTION
While running emerynet tests in CI for liquidation workflows, the environment variables were not picked up in the code. Their values were `undefined`.

After inspecting, I found that we need to pass the secrets to the reusable workflow from where it's being called. You can refer to this [GitHub documentation on using inputs and secrets in a reusable workflow](https://docs.github.com/en/actions/using-workflows/reusing-workflows#using-inputs-and-secrets-in-a-reusable-workflow) for more details.

In our CI setup, we have a file named `reusable.workflow.yml`, which is called in both `liquidation.yml` and `liquidation-reconstitution.yml`. In this PR, I am passing the secrets from these workflows to the reusable workflow.