### PR TITLE
chore: use different timeouts based on network

### DIFF
--- a/test/e2e/specs/liquidation-reconstitution.spec.js
+++ b/test/e2e/specs/liquidation-reconstitution.spec.js
@@ -1,11 +1,4 @@
-import {
-  mnemonics,
-  LIQUIDATING_TIMEOUT,
-  LIQUIDATED_TIMEOUT,
-  MINUTE_MS,
-  networks,
-  configMap,
-} from '../test.utils';
+import { mnemonics, MINUTE_MS, networks, configMap } from '../test.utils';
 
 describe('Wallet App Test Cases', () => {
   let startTime;
@@ -13,6 +6,8 @@ describe('Wallet App Test Cases', () => {
   const currentConfig = configMap[AGORIC_NET];
   const DEFAULT_TIMEOUT = currentConfig.DEFAULT_TIMEOUT;
   const DEFAULT_TASK_TIMEOUT = currentConfig.DEFAULT_TASK_TIMEOUT;
+  const LIQUIDATING_TIMEOUT = currentConfig.LIQUIDATING_TIMEOUT;
+  const LIQUIDATED_TIMEOUT = currentConfig.LIQUIDATED_TIMEOUT;
   const user1Mnemonic = currentConfig.user1Mnemonic;
   const user1Address = currentConfig.user1Address;
   const bidderMnemonic = currentConfig.bidderMnemonic;

--- a/test/e2e/specs/liquidation.spec.js
+++ b/test/e2e/specs/liquidation.spec.js
@@ -1,7 +1,5 @@
 import {
   mnemonics,
-  LIQUIDATING_TIMEOUT,
-  LIQUIDATED_TIMEOUT,
   MINUTE_MS,
   networks,
   configMap,
@@ -14,6 +12,8 @@ describe('Wallet App Test Cases', () => {
   const currentConfig = configMap[AGORIC_NET];
   const DEFAULT_TIMEOUT = currentConfig.DEFAULT_TIMEOUT;
   const DEFAULT_TASK_TIMEOUT = currentConfig.DEFAULT_TASK_TIMEOUT;
+  const LIQUIDATING_TIMEOUT = currentConfig.LIQUIDATING_TIMEOUT;
+  const LIQUIDATED_TIMEOUT = currentConfig.LIQUIDATED_TIMEOUT;
   const user1Mnemonic = currentConfig.user1Mnemonic;
   const user1Address = currentConfig.user1Address;
   const bidderMnemonic = currentConfig.bidderMnemonic;
@@ -420,7 +420,7 @@ describe('Wallet App Test Cases', () => {
     });
 
     it('should wait and verify vaults are being liquidated', () => {
-      cy.contains(/3 vaults are liquidating./, {
+      cy.contains(/vaults are liquidating./, {
         timeout: LIQUIDATING_TIMEOUT,
       });
     });
@@ -477,7 +477,7 @@ describe('Wallet App Test Cases', () => {
       cy.skipWhen(AGORIC_NET === networks.LOCAL);
 
       const propertyName = 'book0.collateralAvailable';
-      const expectedValue = '9.659302 ATOM';
+      const expectedValue = '9.659301 ATOM';
 
       cy.verifyAuctionData(propertyName, expectedValue);
     });

--- a/test/e2e/test.utils.js
+++ b/test/e2e/test.utils.js
@@ -13,8 +13,6 @@ export const accountAddresses = {
 
 export const webWalletURL = 'https://wallet.agoric.app/';
 export const COMMAND_TIMEOUT = 4 * 60 * 1000;
-export const LIQUIDATING_TIMEOUT = 20 * 60 * 1000;
-export const LIQUIDATED_TIMEOUT = 10 * 60 * 1000;
 export const MINUTE_MS = 60000;
 
 export const phrasesList = {
@@ -37,6 +35,8 @@ export const configMap = {
   emerynet: {
     DEFAULT_TIMEOUT: 3 * 60 * 1000,
     DEFAULT_TASK_TIMEOUT: 3 * 60 * 1000,
+    LIQUIDATING_TIMEOUT: 13 * 60 * 1000,
+    LIQUIDATED_TIMEOUT: 5 * 60 * 1000,
     user1Mnemonic:
       Cypress.env('USER1_MNEMONIC_INPUT') || Cypress.env('USER1_MNEMONIC'),
     user1Address:
@@ -57,6 +57,8 @@ export const configMap = {
   local: {
     DEFAULT_TIMEOUT: 1 * 60 * 1000,
     DEFAULT_TASK_TIMEOUT: 1 * 60 * 1000,
+    LIQUIDATING_TIMEOUT: 20 * 60 * 1000,
+    LIQUIDATED_TIMEOUT: 10 * 60 * 1000,
     user1Mnemonic: mnemonics.user1,
     user1Address: accountAddresses.user1,
     bidderMnemonic: mnemonics.gov1,


### PR DESCRIPTION
The PR does the following:
- Makes sure we use different timeouts for liquidation based on network. 
- Modifications in tests to ensure we don't wait much for desired results in case of failure. 
