### PR TITLE
chore: increase command timeout for emerynet

### DIFF
--- a/test/e2e/support.js
+++ b/test/e2e/support.js
@@ -1,7 +1,9 @@
 import '@agoric/synpress/support/index';
-import { networks, COMMAND_TIMEOUT } from './test.utils';
+import { networks, configMap } from './test.utils';
 
 const AGORIC_NET = Cypress.env('AGORIC_NET') || 'local';
+const COMMAND_TIMEOUT = configMap[AGORIC_NET].COMMAND_TIMEOUT;
+
 const agops = '/usr/src/agoric-sdk/packages/agoric-cli/bin/agops';
 
 Cypress.Commands.add('addKeys', params => {

--- a/test/e2e/test.utils.js
+++ b/test/e2e/test.utils.js
@@ -12,7 +12,6 @@ export const accountAddresses = {
 };
 
 export const webWalletURL = 'https://wallet.agoric.app/';
-export const COMMAND_TIMEOUT = 4 * 60 * 1000;
 export const MINUTE_MS = 60000;
 
 export const phrasesList = {
@@ -37,6 +36,7 @@ export const configMap = {
     DEFAULT_TASK_TIMEOUT: 3 * 60 * 1000,
     LIQUIDATING_TIMEOUT: 13 * 60 * 1000,
     LIQUIDATED_TIMEOUT: 5 * 60 * 1000,
+    COMMAND_TIMEOUT: 6 * 60 * 1000,
     user1Mnemonic:
       Cypress.env('USER1_MNEMONIC_INPUT') || Cypress.env('USER1_MNEMONIC'),
     user1Address:
@@ -59,6 +59,7 @@ export const configMap = {
     DEFAULT_TASK_TIMEOUT: 1 * 60 * 1000,
     LIQUIDATING_TIMEOUT: 20 * 60 * 1000,
     LIQUIDATED_TIMEOUT: 10 * 60 * 1000,
+    COMMAND_TIMEOUT: 2 * 60 * 1000,
     user1Mnemonic: mnemonics.user1,
     user1Address: accountAddresses.user1,
     bidderMnemonic: mnemonics.gov1,


### PR DESCRIPTION
Sometimes the command related to creating vaults timeouts with emerynet tests for liquidation. In this PR, I address that issue by using different timeouts for local and emerynet tests. 