### PR TITLE
test: updated tests to reduce flakiness for wallet setup

### DIFF
--- a/test/e2e/specs/test.spec.js
+++ b/test/e2e/specs/test.spec.js
@@ -24,44 +24,9 @@ describe('Vaults UI Test Cases', () => {
 
         cy.getWalletAddress('Agoric').then(address => {
           // provision BLD
-          cy.request({
-            method: 'POST',
-            url: 'https://emerynet.faucet.agoric.net/go',
-            body: {
-              address,
-              command: 'delegate',
-              clientType: 'SMART_WALLET',
-            },
-            headers: {
-              Accept:
-                'text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7',
-              'Content-Type': 'application/x-www-form-urlencoded',
-            },
-            timeout: 4 * MINUTE_MS,
-            retryOnStatusCodeFailure: true,
-          }).then(resp => {
-            expect(resp.body).to.eq('success');
-          });
-
+          cy.provisionFromFaucet(address, 'delegate');
           // provision IST
-          cy.request({
-            method: 'POST',
-            url: 'https://emerynet.faucet.agoric.net/go',
-            body: {
-              address,
-              command: 'client',
-              clientType: 'SMART_WALLET',
-            },
-            headers: {
-              Accept:
-                'text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7',
-              'Content-Type': 'application/x-www-form-urlencoded',
-            },
-            timeout: 4 * MINUTE_MS,
-            retryOnStatusCodeFailure: true,
-          }).then(resp => {
-            expect(resp.body).to.eq('success');
-          });
+          cy.provisionFromFaucet(address, 'client');
         });
       }
     });

--- a/test/e2e/support.js
+++ b/test/e2e/support.js
@@ -1,5 +1,11 @@
 import '@agoric/synpress/support/index';
-import { networks, configMap } from './test.utils';
+import {
+  networks,
+  configMap,
+  FACUET_HEADERS,
+  FACUET_URL,
+  MINUTE_MS,
+} from './test.utils';
 
 const AGORIC_NET = Cypress.env('AGORIC_NET') || 'local';
 const COMMAND_TIMEOUT = configMap[AGORIC_NET].COMMAND_TIMEOUT;
@@ -151,4 +157,21 @@ Cypress.Commands.add('connectWithWallet', () => {
   } else {
     connectWalletEmerynet();
   }
+});
+
+Cypress.Commands.add('provisionFromFaucet', (walletAddress, command) => {
+  cy.request({
+    method: 'POST',
+    url: FACUET_URL,
+    body: {
+      address: walletAddress,
+      command,
+      clientType: 'SMART_WALLET',
+    },
+    headers: FACUET_HEADERS,
+    timeout: 4 * MINUTE_MS,
+    retryOnStatusCodeFailure: true,
+  }).then(resp => {
+    expect(resp.body).to.eq('success');
+  });
 });

--- a/test/e2e/test.utils.js
+++ b/test/e2e/test.utils.js
@@ -74,3 +74,11 @@ export const configMap = {
     econGovURL: 'https://econ-gov.inter.trade/?agoricNet=local',
   },
 };
+
+export const FACUET_URL = 'https://emerynet.faucet.agoric.net/go';
+
+export const FACUET_HEADERS = {
+  Accept:
+    'text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7',
+  'Content-Type': 'application/x-www-form-urlencoded',
+};


### PR DESCRIPTION
This PR makes the following updates to CI tests to reduce flakiness:

- first it updates the flow to get the chain address. we were originally using the wallet dapp for this but a good solution instead is to use the address of the original 'Agoric' chain, since it will be the same for emerynet
- second, it updates the flow for provisoin tokens using the emerynet faucet. previously we were doing it through the emerynet faucet ui, but now we are performing it thorugh direct API request, which allows us to retry on failure