### PR TITLE
reduce flakiness with cleanup tests

### DIFF
--- a/test/e2e/specs/liquidation-reconstitution.spec.js
+++ b/test/e2e/specs/liquidation-reconstitution.spec.js
@@ -417,7 +417,6 @@ describe('Wallet App Test Cases', () => {
         const propertyName = 'book0.startPrice';
         const expectedValue = '9.99 IST/ATOM';
 
-        cy.wait(3000); // eslint-disable-line cypress/no-unnecessary-waiting
         cy.verifyAuctionData(propertyName, expectedValue);
       });
 
@@ -425,7 +424,6 @@ describe('Wallet App Test Cases', () => {
         const propertyName = 'book0.startProceedsGoal';
         const expectedValue = '309.54 IST';
 
-        cy.wait(3000); // eslint-disable-line cypress/no-unnecessary-waiting
         cy.verifyAuctionData(propertyName, expectedValue);
       });
 
@@ -433,7 +431,6 @@ describe('Wallet App Test Cases', () => {
         const propertyName = 'book0.startCollateral';
         const expectedValue = '45 ATOM';
 
-        cy.wait(3000); // eslint-disable-line cypress/no-unnecessary-waiting
         cy.verifyAuctionData(propertyName, expectedValue);
       });
 
@@ -441,7 +438,6 @@ describe('Wallet App Test Cases', () => {
         const propertyName = 'book0.collateralAvailable';
         const expectedValue = '45 ATOM';
 
-        cy.wait(3000); // eslint-disable-line cypress/no-unnecessary-waiting
         cy.verifyAuctionData(propertyName, expectedValue);
       });
 
@@ -478,7 +474,7 @@ describe('Wallet App Test Cases', () => {
         const propertyName = 'book0.collateralAvailable';
         const expectedValue = '31.414987 ATOM';
 
-        cy.wait(3000); // eslint-disable-line cypress/no-unnecessary-waiting
+        cy.wait(ONE_MINUTE_WAIT); // eslint-disable-line cypress/no-unnecessary-waiting
         cy.verifyAuctionData(propertyName, expectedValue);
       });
 

--- a/test/e2e/specs/liquidation-reconstitution.spec.js
+++ b/test/e2e/specs/liquidation-reconstitution.spec.js
@@ -474,7 +474,7 @@ describe('Wallet App Test Cases', () => {
         const propertyName = 'book0.collateralAvailable';
         const expectedValue = '31.414987 ATOM';
 
-        cy.wait(ONE_MINUTE_WAIT); // eslint-disable-line cypress/no-unnecessary-waiting
+        cy.wait(MINUTE_MS); // eslint-disable-line cypress/no-unnecessary-waiting
         cy.verifyAuctionData(propertyName, expectedValue);
       });
 

--- a/test/e2e/specs/liquidation-reconstitution.spec.js
+++ b/test/e2e/specs/liquidation-reconstitution.spec.js
@@ -474,7 +474,7 @@ describe('Wallet App Test Cases', () => {
         const propertyName = 'book0.collateralAvailable';
         const expectedValue = '31.414987 ATOM';
 
-        cy.wait(MINUTE_MS); // eslint-disable-line cypress/no-unnecessary-waiting
+        cy.wait(2 * MINUTE_MS); // eslint-disable-line cypress/no-unnecessary-waiting
         cy.verifyAuctionData(propertyName, expectedValue);
       });
 

--- a/test/e2e/specs/liquidation.spec.js
+++ b/test/e2e/specs/liquidation.spec.js
@@ -4,6 +4,7 @@ import {
   networks,
   configMap,
   webWalletURL,
+  ONE_MINUTE_WAIT,
 } from '../test.utils';
 
 describe('Wallet App Test Cases', () => {
@@ -482,60 +483,41 @@ describe('Wallet App Test Cases', () => {
 
       cy.verifyAuctionData(propertyName, expectedValue);
     });
+  });
 
-    it(
-      'should claim collateral from the first vault successfully',
-      {
-        defaultCommandTimeout: DEFAULT_TIMEOUT,
-        taskTimeout: DEFAULT_TASK_TIMEOUT,
-      },
-      () => {
-        cy.skipWhen(AGORIC_NET === networks.LOCAL);
+  context('Close the vaults and cancel bids', () => {
+    it('should claim collateral from the first vault successfully', () => {
+      cy.skipWhen(AGORIC_NET === networks.LOCAL);
 
-        cy.contains('Click to claim collateral').click();
-        cy.contains('button', 'Close Out Vault').click();
-        cy.acceptAccess().then(taskCompleted => {
-          expect(taskCompleted).to.be.true;
-          cy.contains('button', 'Close Out Vault').should('not.exist');
-        });
-      },
-    );
+      cy.contains(/3.42 ATOM/, { timeout: ONE_MINUTE_WAIT }).click();
+      cy.contains('button', 'Close Out Vault').click();
+      cy.acceptAccess().then(taskCompleted => {
+        expect(taskCompleted).to.be.true;
+        cy.contains('button', 'Close Out Vault').should('not.exist');
+      });
+    });
 
-    it(
-      'should claim collateral from the second vault successfully',
-      {
-        defaultCommandTimeout: DEFAULT_TIMEOUT,
-        taskTimeout: DEFAULT_TASK_TIMEOUT,
-      },
-      () => {
-        cy.skipWhen(AGORIC_NET === networks.LOCAL);
+    it('should claim collateral from the second vault successfully', () => {
+      cy.skipWhen(AGORIC_NET === networks.LOCAL);
 
-        cy.contains('Click to claim collateral').click();
-        cy.contains('button', 'Close Out Vault').click();
-        cy.acceptAccess().then(taskCompleted => {
-          expect(taskCompleted).to.be.true;
-          cy.contains('button', 'Close Out Vault').should('not.exist');
-        });
-      },
-    );
+      cy.contains(/3.07 ATOM/, { timeout: ONE_MINUTE_WAIT }).click();
+      cy.contains('button', 'Close Out Vault').click();
+      cy.acceptAccess().then(taskCompleted => {
+        expect(taskCompleted).to.be.true;
+        cy.contains('button', 'Close Out Vault').should('not.exist');
+      });
+    });
 
-    it(
-      'should claim collateral from the third vault successfully',
-      {
-        defaultCommandTimeout: DEFAULT_TIMEOUT,
-        taskTimeout: DEFAULT_TASK_TIMEOUT,
-      },
-      () => {
-        cy.skipWhen(AGORIC_NET === networks.LOCAL);
+    it('should claim collateral from the third vault successfully', () => {
+      cy.skipWhen(AGORIC_NET === networks.LOCAL);
 
-        cy.contains('Click to claim collateral').click();
-        cy.contains('button', 'Close Out Vault').click();
-        cy.acceptAccess().then(taskCompleted => {
-          expect(taskCompleted).to.be.true;
-          cy.contains('button', 'Close Out Vault').should('not.exist');
-        });
-      },
-    );
+      cy.contains(/2.84 ATOM/, { timeout: ONE_MINUTE_WAIT }).click();
+      cy.contains('button', 'Close Out Vault').click();
+      cy.acceptAccess().then(taskCompleted => {
+        expect(taskCompleted).to.be.true;
+        cy.contains('button', 'Close Out Vault').should('not.exist');
+      });
+    });
 
     it('should set ATOM price back to 12.34', () => {
       cy.skipWhen(AGORIC_NET === networks.LOCAL);

--- a/test/e2e/specs/liquidation.spec.js
+++ b/test/e2e/specs/liquidation.spec.js
@@ -429,28 +429,24 @@ describe('Wallet App Test Cases', () => {
     it('should verify the value of startPrice from the CLI successfully', () => {
       const propertyName = 'book0.startPrice';
       const expectedValue = '9.99 IST/ATOM';
-      cy.wait(3000); // eslint-disable-line cypress/no-unnecessary-waiting
       cy.verifyAuctionData(propertyName, expectedValue);
     });
 
     it('should verify the value of startProceedsGoal from the CLI successfully', () => {
       const propertyName = 'book0.startProceedsGoal';
       const expectedValue = '309.54 IST';
-      cy.wait(3000); // eslint-disable-line cypress/no-unnecessary-waiting
       cy.verifyAuctionData(propertyName, expectedValue);
     });
 
     it('should verify the value of startCollateral from the CLI successfully', () => {
       const propertyName = 'book0.startCollateral';
       const expectedValue = '45 ATOM';
-      cy.wait(3000); // eslint-disable-line cypress/no-unnecessary-waiting
       cy.verifyAuctionData(propertyName, expectedValue);
     });
 
     it('should verify the value of collateralAvailable from the CLI successfully', () => {
       const propertyName = 'book0.collateralAvailable';
       const expectedValue = '45 ATOM';
-      cy.wait(3000); // eslint-disable-line cypress/no-unnecessary-waiting
       cy.verifyAuctionData(propertyName, expectedValue);
     });
 
@@ -479,7 +475,7 @@ describe('Wallet App Test Cases', () => {
 
       const propertyName = 'book0.collateralAvailable';
       const expectedValue = '9.659301 ATOM';
-      cy.wait(3000); // eslint-disable-line cypress/no-unnecessary-waiting
+      cy.wait(ONE_MINUTE_WAIT); // eslint-disable-line cypress/no-unnecessary-waiting
 
       cy.verifyAuctionData(propertyName, expectedValue);
     });
@@ -524,10 +520,13 @@ describe('Wallet App Test Cases', () => {
       cy.setOraclePrice(12.34);
     });
 
+    it('should switch to the bidder wallet successfully', () => {
+      cy.skipWhen(AGORIC_NET === networks.LOCAL);
+      cy.switchWallet(bidderWalletName);
+    });
     it('should setup the web wallet and cancel the 150IST bid', () => {
       cy.skipWhen(AGORIC_NET === networks.LOCAL);
 
-      cy.switchWallet(bidderWalletName);
       cy.visit(webWalletURL);
 
       cy.acceptAccess().then(taskCompleted => {

--- a/test/e2e/specs/liquidation.spec.js
+++ b/test/e2e/specs/liquidation.spec.js
@@ -474,9 +474,8 @@ describe('Wallet App Test Cases', () => {
 
       const propertyName = 'book0.collateralAvailable';
       const expectedValue = '9.659301 ATOM';
-      cy.wait(MINUTE_MS); // eslint-disable-line cypress/no-unnecessary-waiting
-
-      cy.verifyAuctionData(propertyName, expectedValue);
+      cy.wait(2 * MINUTE_MS);
+      cy.verifyAuctionData(propertyName, expectedValue); // eslint-disable-line cypress/no-unnecessary-waiting
     });
   });
 
@@ -489,7 +488,9 @@ describe('Wallet App Test Cases', () => {
       cy.wait(MINUTE_MS);
       cy.acceptAccess().then(taskCompleted => {
         expect(taskCompleted).to.be.true;
-        cy.contains('button', 'Close Out Vault').should('not.exist');
+        cy.contains('button', 'Close Out Vault', {
+          timeout: DEFAULT_TIMEOUT,
+        }).should('not.exist');
       });
     });
 
@@ -501,7 +502,9 @@ describe('Wallet App Test Cases', () => {
       cy.wait(MINUTE_MS);
       cy.acceptAccess().then(taskCompleted => {
         expect(taskCompleted).to.be.true;
-        cy.contains('button', 'Close Out Vault').should('not.exist');
+        cy.contains('button', 'Close Out Vault', {
+          timeout: DEFAULT_TIMEOUT,
+        }).should('not.exist');
       });
     });
 
@@ -513,7 +516,9 @@ describe('Wallet App Test Cases', () => {
       cy.wait(MINUTE_MS);
       cy.acceptAccess().then(taskCompleted => {
         expect(taskCompleted).to.be.true;
-        cy.contains('button', 'Close Out Vault').should('not.exist');
+        cy.contains('button', 'Close Out Vault', {
+          timeout: DEFAULT_TIMEOUT,
+        }).should('not.exist');
       });
     });
 
@@ -574,6 +579,7 @@ describe('Wallet App Test Cases', () => {
 
       cy.getTokenAmount('IST').then(initialTokenValue => {
         cy.contains('Exit').click();
+        cy.wait(MINUTE_MS);
         cy.acceptAccess().then(taskCompleted => {
           expect(taskCompleted).to.be.true;
         });

--- a/test/e2e/specs/liquidation.spec.js
+++ b/test/e2e/specs/liquidation.spec.js
@@ -4,7 +4,6 @@ import {
   networks,
   configMap,
   webWalletURL,
-  ONE_MINUTE_WAIT,
 } from '../test.utils';
 
 describe('Wallet App Test Cases', () => {
@@ -475,7 +474,7 @@ describe('Wallet App Test Cases', () => {
 
       const propertyName = 'book0.collateralAvailable';
       const expectedValue = '9.659301 ATOM';
-      cy.wait(ONE_MINUTE_WAIT); // eslint-disable-line cypress/no-unnecessary-waiting
+      cy.wait(MINUTE_MS); // eslint-disable-line cypress/no-unnecessary-waiting
 
       cy.verifyAuctionData(propertyName, expectedValue);
     });
@@ -485,8 +484,9 @@ describe('Wallet App Test Cases', () => {
     it('should claim collateral from the first vault successfully', () => {
       cy.skipWhen(AGORIC_NET === networks.LOCAL);
 
-      cy.contains(/3.42 ATOM/, { timeout: ONE_MINUTE_WAIT }).click();
+      cy.contains(/3.42 ATOM/, { timeout: MINUTE_MS }).click();
       cy.contains('button', 'Close Out Vault').click();
+      cy.wait(MINUTE_MS);
       cy.acceptAccess().then(taskCompleted => {
         expect(taskCompleted).to.be.true;
         cy.contains('button', 'Close Out Vault').should('not.exist');
@@ -496,8 +496,9 @@ describe('Wallet App Test Cases', () => {
     it('should claim collateral from the second vault successfully', () => {
       cy.skipWhen(AGORIC_NET === networks.LOCAL);
 
-      cy.contains(/3.07 ATOM/, { timeout: ONE_MINUTE_WAIT }).click();
+      cy.contains(/3.07 ATOM/, { timeout: MINUTE_MS }).click();
       cy.contains('button', 'Close Out Vault').click();
+      cy.wait(MINUTE_MS);
       cy.acceptAccess().then(taskCompleted => {
         expect(taskCompleted).to.be.true;
         cy.contains('button', 'Close Out Vault').should('not.exist');
@@ -507,8 +508,9 @@ describe('Wallet App Test Cases', () => {
     it('should claim collateral from the third vault successfully', () => {
       cy.skipWhen(AGORIC_NET === networks.LOCAL);
 
-      cy.contains(/2.84 ATOM/, { timeout: ONE_MINUTE_WAIT }).click();
+      cy.contains(/2.84 ATOM/, { timeout: MINUTE_MS }).click();
       cy.contains('button', 'Close Out Vault').click();
+      cy.wait(MINUTE_MS);
       cy.acceptAccess().then(taskCompleted => {
         expect(taskCompleted).to.be.true;
         cy.contains('button', 'Close Out Vault').should('not.exist');

--- a/test/e2e/test.utils.js
+++ b/test/e2e/test.utils.js
@@ -12,7 +12,7 @@ export const accountAddresses = {
 };
 
 export const webWalletURL = 'https://wallet.agoric.app/';
-export const MINUTE_MS = 60000;
+export const MINUTE_MS = 1 * 60 * 1000;
 
 export const phrasesList = {
   emerynet: {
@@ -82,5 +82,3 @@ export const FACUET_HEADERS = {
     'text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7',
   'Content-Type': 'application/x-www-form-urlencoded',
 };
-
-export const ONE_MINUTE_WAIT = 1 * 60 * 1000;

--- a/test/e2e/test.utils.js
+++ b/test/e2e/test.utils.js
@@ -82,3 +82,5 @@ export const FACUET_HEADERS = {
     'text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7',
   'Content-Type': 'application/x-www-form-urlencoded',
 };
+
+export const ONE_MINUTE_WAIT = 1 * 60 * 1000;


### PR DESCRIPTION
The PR does the following:
- Segregates tests related to closing vaults and canceling bids into a separate context. 
- Removes 3-second wait when verifying auction data. Adding this wait did not bring any stability in the tests. 
- Update the tests related to claiming collateral. Use a different selector and add new timeout values based on the consideration for a busy network. 
- When canceling the bids that are not accepted, sometimes there is flaky behavior when switching to a new wallet. I've been inspecting this but not sure why that tends to happen. Switching the wallet in a separate test case solves the problem. 