### PR TITLE
Add GH workflows to facilitate autonomous deploy to CF

### DIFF
--- a/.github/workflows/deploy-poller.yml
+++ b/.github/workflows/deploy-poller.yml
@@ -2,8 +2,8 @@ name: Poll for changes to start a deploy to CF
 
 on:
   schedule:
-    - cron: '*/5 * * * *'  # Runs every 5 minutes
-  workflow_dispatch:  # Allows manual triggering of the workflow
+    - cron: '*/5 * * * *' # Runs every 5 minutes
+  workflow_dispatch: # Allows manual triggering of the workflow
 
 jobs:
   run-command:
@@ -23,7 +23,7 @@ jobs:
             echo "CHAIN_URL is not set. Skipping workflow."
             exit 0
           fi
-          
+
           if [ -z "${{ vars.DEPLOY_BRANCH }}" ]; then
             echo "DEPLOY_BRANCH environment variable does not exist."
             echo "HAS_DEPLOY_BRANCH=false" >> $GITHUB_ENV
@@ -41,7 +41,7 @@ jobs:
 
           # Fetch the new value
           NEW_REFERENCED_UI=$(curl -s $URL | jq -r '.value' | jq -r '.values[]' | jq -r .body | sed 's/^#//' | jq -r .current.ReferencedUI.value)
-          
+
           # Path to store the previous value
           OLD_REFERENCED_UI_FILE="./DEPLOYED_HASH"
 
@@ -64,7 +64,7 @@ jobs:
           # Check out the specific commit
           git fetch origin
           git checkout ${{ env.NEW_VALUE }}
-          
+
           # Get the deploy branch name from the environment variable
           DEPLOY_BRANCH="${{ vars.DEPLOY_BRANCH }}"
 
@@ -77,7 +77,7 @@ jobs:
         run: |
           git fetch origin
           git checkout main
-          
+
           # Define the path to the previous value file
           REFERENCED_UI_FILE="./DEPLOYED_HASH"
 

--- a/.github/workflows/deploy-poller.yml
+++ b/.github/workflows/deploy-poller.yml
@@ -41,7 +41,6 @@ jobs:
 
           # Fetch the new value
           NEW_REFERENCED_UI=$(curl -s $URL | jq -r '.value' | jq -r '.values[]' | jq -r .body | sed 's/^#//' | jq -r .current.ReferencedUI.value)
-          NEW_REFERENCED_UI=ae140e2780f14d5de64217ab9a67a4cc9a3f4ed2
           
           # Path to store the previous value
           OLD_REFERENCED_UI_FILE="./DEPLOYED_HASH"
@@ -59,22 +58,6 @@ jobs:
           echo "NEW_VALUE=$NEW_REFERENCED_UI" >> $GITHUB_ENV
           echo "PREVIOUS_VALUE=$OLD_REFERENCED_UI" >> $GITHUB_ENV
 
-      - name: Update DEPLOYED_HASH if value changed
-        if: env.NEW_VALUE != env.PREVIOUS_VALUE && steps.check_variables.outcome == 'success' && env.HAS_DEPLOY_BRANCH == 'true'
-        run: |
-          # Define the path to the previous value file
-          REFERENCED_UI_FILE="./DEPLOYED_HASH"
-
-          # Save the new value to the DEPLOYED_HASH file
-          echo "$NEW_VALUE" > $REFERENCED_UI_FILE
-
-          # Configure git and commit changes
-          git config user.name "github-actions"
-          git config user.email "github-actions@github.com"
-          git add $REFERENCED_UI_FILE
-          git commit -m "Update DEPLOYED_HASH with new value"
-          git push
-
       - name: Checkout the specific commit and deploy
         if: env.NEW_VALUE != env.PREVIOUS_VALUE && steps.check_variables.outcome == 'success' && env.HAS_DEPLOY_BRANCH == 'true'
         run: |
@@ -88,3 +71,22 @@ jobs:
           # Create or update the deploy branch
           git checkout -B $DEPLOY_BRANCH
           git push -f origin $DEPLOY_BRANCH
+
+      - name: Commit DEPLOYED_HASH if value changed
+        if: env.NEW_VALUE != env.PREVIOUS_VALUE && steps.check_variables.outcome == 'success' && env.HAS_DEPLOY_BRANCH == 'true'
+        run: |
+          git fetch origin
+          git checkout main
+          
+          # Define the path to the previous value file
+          REFERENCED_UI_FILE="./DEPLOYED_HASH"
+
+          # Save the new value to the DEPLOYED_HASH file
+          echo "$NEW_VALUE" > $REFERENCED_UI_FILE
+
+          # Configure git and commit changes
+          git config user.name "github-actions"
+          git config user.email "github-actions@github.com"
+          git add $REFERENCED_UI_FILE
+          git commit -m "Update DEPLOYED_HASH with new value"
+          git push

--- a/.github/workflows/deploy-poller.yml
+++ b/.github/workflows/deploy-poller.yml
@@ -1,0 +1,90 @@
+name: Poll for changes to start a deploy to CF
+
+on:
+  schedule:
+    - cron: '*/5 * * * *'  # Runs every 5 minutes
+  workflow_dispatch:  # Allows manual triggering of the workflow
+
+jobs:
+  run-command:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Install jq
+        run: sudo apt-get install -y jq
+
+      - name: Check for required variables
+        id: check_variables
+        run: |
+          if [ -z "${{ vars.CHAIN_URL }}" ]; then
+            echo "CHAIN_URL is not set. Skipping workflow."
+            exit 0
+          fi
+          
+          if [ -z "${{ vars.DEPLOY_BRANCH }}" ]; then
+            echo "DEPLOY_BRANCH environment variable does not exist."
+            echo "HAS_DEPLOY_BRANCH=false" >> $GITHUB_ENV
+          else
+            echo "DEPLOY_BRANCH environment variable found."
+            echo "HAS_DEPLOY_BRANCH=true" >> $GITHUB_ENV
+            echo "DEPLOY_BRANCH=${{ vars.DEPLOY_BRANCH }}" >> $GITHUB_ENV
+          fi
+
+      - name: Run bash command
+        if: steps.check_variables.outcome == 'success' && env.HAS_DEPLOY_BRANCH == 'true'
+        run: |
+          # Define the URL from the environment variable
+          URL="${{ vars.CHAIN_URL }}/agoric/vstorage/data/published.vaultFactory.governance"
+
+          # Fetch the new value
+          NEW_REFERENCED_UI=$(curl -s $URL | jq -r '.value' | jq -r '.values[]' | jq -r .body | sed 's/^#//' | jq -r .current.ReferencedUI.value)
+          NEW_REFERENCED_UI=ae140e2780f14d5de64217ab9a67a4cc9a3f4ed2
+          
+          # Path to store the previous value
+          OLD_REFERENCED_UI_FILE="./DEPLOYED_HASH"
+
+          # Check if the previous value exists
+          if [ -f "$OLD_REFERENCED_UI_FILE" ]; then
+            # Read the previous value
+            OLD_REFERENCED_UI=$(cat $OLD_REFERENCED_UI_FILE)
+          else
+            # File does not exist, set previous value to empty
+            OLD_REFERENCED_UI=""
+          fi
+
+          # Output the values for the next step
+          echo "NEW_VALUE=$NEW_REFERENCED_UI" >> $GITHUB_ENV
+          echo "PREVIOUS_VALUE=$OLD_REFERENCED_UI" >> $GITHUB_ENV
+
+      - name: Update DEPLOYED_HASH if value changed
+        if: env.NEW_VALUE != env.PREVIOUS_VALUE && steps.check_variables.outcome == 'success' && env.HAS_DEPLOY_BRANCH == 'true'
+        run: |
+          # Define the path to the previous value file
+          REFERENCED_UI_FILE="./DEPLOYED_HASH"
+
+          # Save the new value to the DEPLOYED_HASH file
+          echo "$NEW_VALUE" > $REFERENCED_UI_FILE
+
+          # Configure git and commit changes
+          git config user.name "github-actions"
+          git config user.email "github-actions@github.com"
+          git add $REFERENCED_UI_FILE
+          git commit -m "Update DEPLOYED_HASH with new value"
+          git push
+
+      - name: Checkout the specific commit and deploy
+        if: env.NEW_VALUE != env.PREVIOUS_VALUE && steps.check_variables.outcome == 'success' && env.HAS_DEPLOY_BRANCH == 'true'
+        run: |
+          # Check out the specific commit
+          git fetch origin
+          git checkout ${{ env.NEW_VALUE }}
+          
+          # Get the deploy branch name from the environment variable
+          DEPLOY_BRANCH="${{ vars.DEPLOY_BRANCH }}"
+
+          # Create or update the deploy branch
+          git checkout -B $DEPLOY_BRANCH
+          git push -f origin $DEPLOY_BRANCH

--- a/.github/workflows/upstream-sync.yml
+++ b/.github/workflows/upstream-sync.yml
@@ -1,0 +1,72 @@
+name: Sync Release with Upstream
+
+on:
+  schedule:
+    # Runs every 5 minutes
+    - cron: '*/5 * * * *'
+
+  # Allows you to manually trigger the workflow from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout the forked repository
+      uses: actions/checkout@v3
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        persist-credentials: false # We disable this because we will be using a different token
+
+    - name: Check for UPSTREAM_URL and UPSTREAM_SYNC_BRANCH_NAME in environment
+      id: check_variables
+      run: |
+        if [ -z "${{ vars.UPSTREAM_URL }}" ]; then
+          echo "UPSTREAM_URL environment variable does not exist."
+          echo "HAS_UPSTREAM=false" >> $GITHUB_ENV
+        else
+          echo "UPSTREAM_URL environment variable found."
+          echo "HAS_UPSTREAM=true" >> $GITHUB_ENV
+          echo "UPSTREAM_URL=${{ vars.UPSTREAM_URL }}" >> $GITHUB_ENV
+        fi
+
+        if [ -z "${{ vars.UPSTREAM_SYNC_BRANCH_NAME }}" ]; then
+          echo "UPSTREAM_SYNC_BRANCH_NAME environment variable does not exist."
+          echo "HAS_SYNC_BRANCH=false" >> $GITHUB_ENV
+        else
+          echo "UPSTREAM_SYNC_BRANCH_NAME environment variable found."
+          echo "HAS_SYNC_BRANCH=true" >> $GITHUB_ENV
+          echo "UPSTREAM_SYNC_BRANCH_NAME=${{ vars.UPSTREAM_SYNC_BRANCH_NAME }}" >> $GITHUB_ENV
+        fi
+
+    - name: Configure git for GitHub Actions
+      if: env.HAS_UPSTREAM == 'true' && env.HAS_SYNC_BRANCH == 'true'
+      run: |
+        git config user.name "github-actions[bot]"
+        git config user.email "github-actions[bot]@users.noreply.github.com"
+
+    - name: Add the upstream repository
+      if: env.HAS_UPSTREAM == 'true' && env.HAS_SYNC_BRANCH == 'true'
+      run: git remote add upstream ${{ env.UPSTREAM_URL }}
+
+    - name: Fetch all branches from the upstream repository
+      if: env.HAS_UPSTREAM == 'true' && env.HAS_SYNC_BRANCH == 'true'
+      run: git fetch upstream
+
+    - name: Set up authentication
+      if: env.HAS_UPSTREAM == 'true' && env.HAS_SYNC_BRANCH == 'true'
+      run: |
+        git remote set-url origin https://${{ github.actor }}:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_ACTOR: ${{ github.actor }}
+
+    - name: Merge upstream/main into forked repo branch
+      if: env.HAS_UPSTREAM == 'true' && env.HAS_SYNC_BRANCH == 'true'
+      run: |
+        git checkout -B ${{ env.UPSTREAM_SYNC_BRANCH_NAME }} upstream/main
+        git push -f origin ${{ env.UPSTREAM_SYNC_BRANCH_NAME }}
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_ACTOR: ${{ github.actor }}

--- a/.github/workflows/upstream-sync.yml
+++ b/.github/workflows/upstream-sync.yml
@@ -13,60 +13,60 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Checkout the forked repository
-      uses: actions/checkout@v3
-      with:
-        token: ${{ secrets.GITHUB_TOKEN }}
-        persist-credentials: false # We disable this because we will be using a different token
+      - name: Checkout the forked repository
+        uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          persist-credentials: false # We disable this because we will be using a different token
 
-    - name: Check for UPSTREAM_URL and UPSTREAM_SYNC_BRANCH_NAME in environment
-      id: check_variables
-      run: |
-        if [ -z "${{ vars.UPSTREAM_URL }}" ]; then
-          echo "UPSTREAM_URL environment variable does not exist."
-          echo "HAS_UPSTREAM=false" >> $GITHUB_ENV
-        else
-          echo "UPSTREAM_URL environment variable found."
-          echo "HAS_UPSTREAM=true" >> $GITHUB_ENV
-          echo "UPSTREAM_URL=${{ vars.UPSTREAM_URL }}" >> $GITHUB_ENV
-        fi
+      - name: Check for UPSTREAM_URL and UPSTREAM_SYNC_BRANCH_NAME in environment
+        id: check_variables
+        run: |
+          if [ -z "${{ vars.UPSTREAM_URL }}" ]; then
+            echo "UPSTREAM_URL environment variable does not exist."
+            echo "HAS_UPSTREAM=false" >> $GITHUB_ENV
+          else
+            echo "UPSTREAM_URL environment variable found."
+            echo "HAS_UPSTREAM=true" >> $GITHUB_ENV
+            echo "UPSTREAM_URL=${{ vars.UPSTREAM_URL }}" >> $GITHUB_ENV
+          fi
 
-        if [ -z "${{ vars.UPSTREAM_SYNC_BRANCH_NAME }}" ]; then
-          echo "UPSTREAM_SYNC_BRANCH_NAME environment variable does not exist."
-          echo "HAS_SYNC_BRANCH=false" >> $GITHUB_ENV
-        else
-          echo "UPSTREAM_SYNC_BRANCH_NAME environment variable found."
-          echo "HAS_SYNC_BRANCH=true" >> $GITHUB_ENV
-          echo "UPSTREAM_SYNC_BRANCH_NAME=${{ vars.UPSTREAM_SYNC_BRANCH_NAME }}" >> $GITHUB_ENV
-        fi
+          if [ -z "${{ vars.UPSTREAM_SYNC_BRANCH_NAME }}" ]; then
+            echo "UPSTREAM_SYNC_BRANCH_NAME environment variable does not exist."
+            echo "HAS_SYNC_BRANCH=false" >> $GITHUB_ENV
+          else
+            echo "UPSTREAM_SYNC_BRANCH_NAME environment variable found."
+            echo "HAS_SYNC_BRANCH=true" >> $GITHUB_ENV
+            echo "UPSTREAM_SYNC_BRANCH_NAME=${{ vars.UPSTREAM_SYNC_BRANCH_NAME }}" >> $GITHUB_ENV
+          fi
 
-    - name: Configure git for GitHub Actions
-      if: env.HAS_UPSTREAM == 'true' && env.HAS_SYNC_BRANCH == 'true'
-      run: |
-        git config user.name "github-actions[bot]"
-        git config user.email "github-actions[bot]@users.noreply.github.com"
+      - name: Configure git for GitHub Actions
+        if: env.HAS_UPSTREAM == 'true' && env.HAS_SYNC_BRANCH == 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
 
-    - name: Add the upstream repository
-      if: env.HAS_UPSTREAM == 'true' && env.HAS_SYNC_BRANCH == 'true'
-      run: git remote add upstream ${{ env.UPSTREAM_URL }}
+      - name: Add the upstream repository
+        if: env.HAS_UPSTREAM == 'true' && env.HAS_SYNC_BRANCH == 'true'
+        run: git remote add upstream ${{ env.UPSTREAM_URL }}
 
-    - name: Fetch all branches from the upstream repository
-      if: env.HAS_UPSTREAM == 'true' && env.HAS_SYNC_BRANCH == 'true'
-      run: git fetch upstream
+      - name: Fetch all branches from the upstream repository
+        if: env.HAS_UPSTREAM == 'true' && env.HAS_SYNC_BRANCH == 'true'
+        run: git fetch upstream
 
-    - name: Set up authentication
-      if: env.HAS_UPSTREAM == 'true' && env.HAS_SYNC_BRANCH == 'true'
-      run: |
-        git remote set-url origin https://${{ github.actor }}:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        GITHUB_ACTOR: ${{ github.actor }}
+      - name: Set up authentication
+        if: env.HAS_UPSTREAM == 'true' && env.HAS_SYNC_BRANCH == 'true'
+        run: |
+          git remote set-url origin https://${{ github.actor }}:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_ACTOR: ${{ github.actor }}
 
-    - name: Merge upstream/main into forked repo branch
-      if: env.HAS_UPSTREAM == 'true' && env.HAS_SYNC_BRANCH == 'true'
-      run: |
-        git checkout -B ${{ env.UPSTREAM_SYNC_BRANCH_NAME }} upstream/main
-        git push -f origin ${{ env.UPSTREAM_SYNC_BRANCH_NAME }}
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        GITHUB_ACTOR: ${{ github.actor }}
+      - name: Merge upstream/main into forked repo branch
+        if: env.HAS_UPSTREAM == 'true' && env.HAS_SYNC_BRANCH == 'true'
+        run: |
+          git checkout -B ${{ env.UPSTREAM_SYNC_BRANCH_NAME }} upstream/main
+          git push -f origin ${{ env.UPSTREAM_SYNC_BRANCH_NAME }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_ACTOR: ${{ github.actor }}


### PR DESCRIPTION
Closes https://github.com/Agoric/product-tasks/issues/107
Closes https://github.com/Agoric/product-tasks/issues/111

This change introduces two workflows that work in tandem to facilitate automated deploy of `dapp-inter`. Steps are as follows:
1. `upstream-sync` will monitor, at a five minute cadence, for new changes on the upstream branch. If any changes have been detected, we'll update our tracking branch to mirror the new `main` branch of the upstream branch.
2. When it's time to vote on a new deploy, we'll take the commit hash of the candidate and save it to `ReferenceUI` in.
3. `deploy-poller` will monitor, at a five minute cadence, for any updates to the `ReferenceUI` value in vstorage. If a change is detected, it will proceed with taking the `ReferenceUI` commit and pushing it to the deploy branch, where CloudFlare takes over

In order for this flow to work, we've introduced a few new variables in GitHub Actions:
- `CHAIN_URL`. The url of the chain. This is needed to poll vstorage
- `DEPLOY_BRANCH`. The branch that will be updated when a new `ReferenceUI` value is detected. This should be configured in CloudFlare to automatically kick start the build process
- `UPSTREAM_SYNC_BRANCH_NAME`. The name of the branch that will be kept up to date with the upstream's `main` branch.

We've also added a new file, `DEPLOYED_HASH`, that keeps track of the last hash used to deploy to CF. When `deploy-poller` finds a new hash, it will make a commit to overwrite the value and push it to `main`. This also prevents us from deploying the same hash over and over.