### PR TITLE
ci: change docker-compose to docker compose

### DIFF
--- a/.github/workflows/liquidation-reconstitution.yml
+++ b/.github/workflows/liquidation-reconstitution.yml
@@ -45,7 +45,7 @@ jobs:
     uses: ./.github/workflows/reusable-workflow.yml
     with:
       docker_compose_command: |
-        docker-compose -f test/e2e/docker-compose-reconstitution.yml \
+        docker compose -f test/e2e/docker-compose-reconstitution.yml \
         --profile synpress up --build \
         --exit-code-from synpress
       is_emerynet_test: ${{ inputs.network == 'emerynet' }}

--- a/.github/workflows/liquidation.yml
+++ b/.github/workflows/liquidation.yml
@@ -45,7 +45,7 @@ jobs:
     uses: ./.github/workflows/reusable-workflow.yml
     with:
       docker_compose_command: |
-        docker-compose -f test/e2e/docker-compose-liquidation.yml \
+        docker compose -f test/e2e/docker-compose-liquidation.yml \
         --profile synpress up --build \
         --exit-code-from synpress
       is_emerynet_test: ${{ inputs.network == 'emerynet' }}

--- a/.github/workflows/reusable-workflow.yml
+++ b/.github/workflows/reusable-workflow.yml
@@ -55,20 +55,6 @@ jobs:
           project_id: 'simulationlab'
           workload_identity_provider: 'projects/60745596728/locations/global/workloadIdentityPools/github/providers/dapp-inter'
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-
-      - name: Cache Docker layers
-        uses: actions/cache@v3
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-buildx-
-
       - name: Run e2e tests
         run: ${{ inputs.docker_compose_command }}
         env:

--- a/.github/workflows/vaults.yml
+++ b/.github/workflows/vaults.yml
@@ -32,7 +32,7 @@ jobs:
     uses: ./.github/workflows/reusable-workflow.yml
     with:
       docker_compose_command: |
-        docker-compose -f test/e2e/docker-compose-vaults.yml \
+        docker compose -f test/e2e/docker-compose-vaults.yml \
         --profile $SYNPRESS_PROFILE up --build \
         --exit-code-from synpress
       is_emerynet_test: ${{ github.event_name == 'schedule' || inputs.network == 'emerynet' }}


### PR DESCRIPTION
Refs: https://github.com/Agoric/dapp-econ-gov/issues/111
Fixes some flakes in e2e testing.

- Firstly used docker compose instead of docker-compose (which is not being recognized by github actions)
- Secondly removed some unnecessary steps to give some space to the github runner, otherwise the job was failing due to space limit being reached