### PR TITLE
test: added conditional check for 'Keep using old version' button

### DIFF
--- a/test/e2e/specs/test.spec.js
+++ b/test/e2e/specs/test.spec.js
@@ -37,7 +37,13 @@ describe('Vaults UI Test Cases', () => {
         cy.contains('button', 'Dismiss').click();
         cy.get('button').contains('Local Network').click();
         cy.get('button').contains(networkPhrases.interNetwork).click();
-        cy.get('button').contains('Keep using Old Version').click();
+        cy.get('body').then($body => {
+          if (
+            $body.find('button:contains("Keep using Old Version")').length > 0
+          ) {
+            cy.get('button').contains('Keep using Old Version').click();
+          }
+        });
       }
 
       cy.contains('Connect Wallet').click();


### PR DESCRIPTION
Fixes: #340 

The "Keep using old version" button appears depending on the current version of dapp being used. so it might appear or not depending on the version being used.
Since this exists/does not exist case can introduce unexpected failures in the e2e tests, the line of code referencing it has been made conditional depending on whether the button is found or not.