### PR TITLE
Fix workflow permissions for upstream sync workflow

### DIFF
--- a/.github/workflows/upstream-sync.yml
+++ b/.github/workflows/upstream-sync.yml
@@ -66,6 +66,23 @@ jobs:
         if: env.HAS_UPSTREAM == 'true' && env.HAS_SYNC_BRANCH == 'true'
         run: |
           git checkout -B ${{ env.UPSTREAM_SYNC_BRANCH_NAME }} upstream/main
+
+          # GitHub Actions worker doesn't have the correct permissions to checked in
+          # modified workflow files. To workaround this, we'll remove all files in 
+          # .github/workflows that doesn't exist on the remote
+
+          # Remove files not on the remote
+          rm -rf .github/workflows
+
+          # Check if the deploy branch exists on the remote
+          if git ls-remote --exit-code --heads origin ${{ env.UPSTREAM_SYNC_BRANCH_NAME }}; then
+            # Mirror remote workflows if they exist
+            if git ls-tree --name-only -r origin/${{ env.UPSTREAM_SYNC_BRANCH_NAME }}:.github/workflows &> /dev/null; then
+              git checkout origin/${{ env.UPSTREAM_SYNC_BRANCH_NAME }} .github/workflows
+            fi
+          fi
+
+          git commit -am "Prepare branch for deploy"
           git push -f origin ${{ env.UPSTREAM_SYNC_BRANCH_NAME }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
When syncing, it's possible that the workflow folder has also changed. Unfortunately, the default Actions worker doesn't have the correct permissions to check in modified workflow files. To workaround this, we always ensure that when we push changes, we remove all files in the `.github/workflows` directory that don't exist on the remote.

![Screenshot 2024-08-16 at 11 19 33 AM](https://github.com/user-attachments/assets/7512167c-3e46-4e12-89d4-fb1b7c0521f3)

