### PR TITLE
ci: label triggered liquidation testing

### DIFF
--- a/.github/workflows/liquidation-reconstitution.yml
+++ b/.github/workflows/liquidation-reconstitution.yml
@@ -34,14 +34,17 @@ on:
         required: false
         default: latest
         type: string
+  pull_request:
+    types:
+      - labeled
 
 concurrency:
-  group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label ||
-    github.head_ref || github.ref }}'
+  group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'
   cancel-in-progress: true
 
 jobs:
   run-e2e:
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || contains(github.event.label.name, 'liquidation-reconstitution-testing')
     uses: ./.github/workflows/reusable-workflow.yml
     with:
       docker_compose_command: |

--- a/.github/workflows/liquidation-reconstitution.yml
+++ b/.github/workflows/liquidation-reconstitution.yml
@@ -37,14 +37,19 @@ on:
   pull_request:
     types:
       - labeled
+      - unlabeled
+      - synchronize
 
 concurrency:
-  group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
   run-e2e:
-    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || contains(github.event.label.name, 'liquidation-reconstitution-testing')
+    if: >-
+      github.event_name != 'pull_request' || github.event_name == 'schedule' || 
+      github.event_name == 'workflow_dispatch' || 
+      contains(github.event.pull_request.labels.*.name, 'liquidation-reconstitution-testing')
     uses: ./.github/workflows/reusable-workflow.yml
     with:
       docker_compose_command: |

--- a/.github/workflows/liquidation-reconstitution.yml
+++ b/.github/workflows/liquidation-reconstitution.yml
@@ -37,7 +37,6 @@ on:
   pull_request:
     types:
       - labeled
-      - unlabeled
       - synchronize
 
 concurrency:
@@ -47,7 +46,7 @@ concurrency:
 jobs:
   run-e2e:
     if: >-
-      github.event_name != 'pull_request' || github.event_name == 'schedule' || 
+      github.event_name == 'schedule' || 
       github.event_name == 'workflow_dispatch' || 
       contains(github.event.pull_request.labels.*.name, 'liquidation-reconstitution-testing')
     uses: ./.github/workflows/reusable-workflow.yml
@@ -56,7 +55,7 @@ jobs:
         docker compose -f test/e2e/docker-compose-reconstitution.yml \
         --profile synpress up --build \
         --exit-code-from synpress
-      is_emerynet_test: ${{ inputs.network == 'emerynet' }}
+      is_emerynet_test: ${{ inputs.network == 'emerynet' || contains(github.event.pull_request.labels.*.name, 'emerynet') }}
       user1_mnemonic: ${{ inputs.user1_mnemonic }}
       user1_address: ${{ inputs.user1_address }}
       bidder_mnemonic: ${{ inputs.bidder_mnemonic }}

--- a/.github/workflows/liquidation.yml
+++ b/.github/workflows/liquidation.yml
@@ -37,7 +37,6 @@ on:
   pull_request:
     types:
       - labeled
-      - unlabeled
       - synchronize
 
 concurrency:
@@ -47,7 +46,7 @@ concurrency:
 jobs:
   run-e2e:
     if: >-
-      github.event_name != 'pull_request' || github.event_name == 'schedule' || 
+      github.event_name == 'schedule' || 
       github.event_name == 'workflow_dispatch' ||
       contains(github.event.pull_request.labels.*.name, 'liquidation-testing')
     uses: ./.github/workflows/reusable-workflow.yml
@@ -56,7 +55,7 @@ jobs:
         docker compose -f test/e2e/docker-compose-liquidation.yml \
         --profile synpress up --build \
         --exit-code-from synpress
-      is_emerynet_test: ${{ inputs.network == 'emerynet' }}
+      is_emerynet_test: ${{ inputs.network == 'emerynet' || contains(github.event.pull_request.labels.*.name, 'emerynet') }}
       user1_mnemonic: ${{ inputs.user1_mnemonic }}
       user1_address: ${{ inputs.user1_address }}
       bidder_mnemonic: ${{ inputs.bidder_mnemonic }}

--- a/.github/workflows/liquidation.yml
+++ b/.github/workflows/liquidation.yml
@@ -37,14 +37,19 @@ on:
   pull_request:
     types:
       - labeled
+      - unlabeled
+      - synchronize
 
 concurrency:
-  group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
   run-e2e:
-    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || contains(github.event.label.name, 'liquidation-testing')
+    if: >-
+      github.event_name != 'pull_request' || github.event_name == 'schedule' || 
+      github.event_name == 'workflow_dispatch' ||
+      contains(github.event.pull_request.labels.*.name, 'liquidation-testing')
     uses: ./.github/workflows/reusable-workflow.yml
     with:
       docker_compose_command: |

--- a/.github/workflows/liquidation.yml
+++ b/.github/workflows/liquidation.yml
@@ -34,14 +34,17 @@ on:
         required: false
         default: latest
         type: string
+  pull_request:
+    types:
+      - labeled
 
 concurrency:
-  group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label ||
-    github.head_ref || github.ref }}'
+  group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'
   cancel-in-progress: true
 
 jobs:
   run-e2e:
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || contains(github.event.label.name, 'liquidation-testing')
     uses: ./.github/workflows/reusable-workflow.yml
     with:
       docker_compose_command: |


### PR DESCRIPTION
The PR introduces the capability to trigger liquidation end-to-end tests using labels. Previously, for liquidation testing, we had to either test things locally or wait for our PR to be merged into the main branch before triggering the liquidation workflows. 

In this PR, we bring these capabilities:

- Adding the `liquidation-testing label` to a PR will trigger all liquidation tests.
- Adding the `liquidation-reconstitution-testing` label to a PR will trigger all liquidation reconstitution tests.
- Adding the `emerynet` label will trigger the Liquidation and Liquidation Reconstitution tests against the Emerynet network, provided that the `liquidation-testing` or `liquidation-reconstitution` labels have also been added to the PR.
