### PR TITLE
ci: use docker compose profiles in liquidation tests

### DIFF
--- a/.github/workflows/liquidation-reconstitution.yml
+++ b/.github/workflows/liquidation-reconstitution.yml
@@ -53,7 +53,7 @@ jobs:
     with:
       docker_compose_command: |
         docker compose -f test/e2e/docker-compose-reconstitution.yml \
-        --profile synpress up --build \
+        --profile $SYNPRESS_PROFILE up --build \
         --exit-code-from synpress
       is_emerynet_test: ${{ inputs.network == 'emerynet' || contains(github.event.pull_request.labels.*.name, 'emerynet') }}
       user1_mnemonic: ${{ inputs.user1_mnemonic }}

--- a/.github/workflows/liquidation.yml
+++ b/.github/workflows/liquidation.yml
@@ -53,7 +53,7 @@ jobs:
     with:
       docker_compose_command: |
         docker compose -f test/e2e/docker-compose-liquidation.yml \
-        --profile synpress up --build \
+        --profile $SYNPRESS_PROFILE up --build \
         --exit-code-from synpress
       is_emerynet_test: ${{ inputs.network == 'emerynet' || contains(github.event.pull_request.labels.*.name, 'emerynet') }}
       user1_mnemonic: ${{ inputs.user1_mnemonic }}

--- a/test/e2e/docker-compose-liquidation.yml
+++ b/test/e2e/docker-compose-liquidation.yml
@@ -7,7 +7,6 @@ services:
     depends_on:
       - display
       - video
-      - agd
     command: >
       bash -c '
         # Display local noVNC URL

--- a/test/e2e/docker-compose-reconstitution.yml
+++ b/test/e2e/docker-compose-reconstitution.yml
@@ -7,7 +7,6 @@ services:
     depends_on:
       - display
       - video
-      - agd
     command: >
       bash -c '
         # Display local noVNC URL


### PR DESCRIPTION
When liquidation tests are triggered, the Agoric local chain is also started. However, we don’t need the local chain when the tests are triggered with Emerynet. This PR resolves this issue by utilizing Docker Compose profiles. It reuses the profiles already used in the E2E tests for vaults.