### PR TITLE
test: fix connect wallet test case

### DIFF
--- a/test/e2e/specs/test.spec.js
+++ b/test/e2e/specs/test.spec.js
@@ -31,28 +31,7 @@ describe('Vaults UI Test Cases', () => {
     });
 
     it('should connect with the wallet', () => {
-      cy.visit('/');
-
-      if (!networkPhrases.isLocal) {
-        cy.contains('button', 'Dismiss').click();
-        cy.get('button').contains('Local Network').click();
-        cy.get('button').contains(networkPhrases.interNetwork).click();
-        cy.get('body').then($body => {
-          if (
-            $body.find('button:contains("Keep using Old Version")').length > 0
-          ) {
-            cy.get('button').contains('Keep using Old Version').click();
-          }
-        });
-      }
-
-      cy.contains('Connect Wallet').click();
-
-      cy.acceptAccess();
-      cy.get('label input[type="checkbox"]').check();
-      cy.contains('Proceed').click();
-
-      cy.acceptAccess();
+      cy.connectWithWallet({ isVaultsTests: true });
     });
 
     it('should create a new vault and approve the transaction successfully', () => {


### PR DESCRIPTION
While running liquidation tests on Emerynet, I encountered a failure in the test related to connecting with the wallet. Interestingly, this issue had already been resolved by @frazarshad in PR #339 for the vault end-to-end tests. The process for connecting a wallet when using a local chain or Emerynet is the same for both vault and liquidation tests.

In this pull request, I've applied the changes from PR #339 to the custom command used for wallet connection. I also updated the vault tests to use this custom command when connecting to the wallet. This ensures consistency across both vault and liquidation tests, making it easier to identify and fix any future errors.
