### PR TITLE
test: show logs after failing test

### DIFF
--- a/test/e2e/support.js
+++ b/test/e2e/support.js
@@ -175,3 +175,11 @@ Cypress.Commands.add('provisionFromFaucet', (walletAddress, command) => {
     expect(resp.body).to.eq('success');
   });
 });
+
+afterEach(function () {
+  if (this.currentTest.state === 'failed') {
+    const testName = this.currentTest.title;
+    const errorMessage = this.currentTest.err.message;
+    cy.task('info', `Test "${testName}" failed with error: ${errorMessage}`);
+  }
+});


### PR DESCRIPTION
Currently, Cypress primarily displays test failures in the Cypress Command Console within the browser. While this works fine locally, allowing you to instantly see the reasons for test failures, it's not feasible in a CI environment. To address this, the PR introduces functionality that outputs the test failure reasons directly to the terminal (stdout) as soon as a test fails.

Here’s an example workflow where I successfully retrieved the reasons for some test failures:
https://github.com/Agoric/dapp-inter/actions/runs/10489730491/job/29055008052