### PR TITLE
ci: input tags for a3p

### DIFF
--- a/.github/workflows/liquidation-reconstitution.yml
+++ b/.github/workflows/liquidation-reconstitution.yml
@@ -32,22 +32,6 @@ on:
         description: 'bidder account address'
         required: false
         type: string
-      gov1_mnemonic:
-        description: 'Mnemonic for gov1 wallet'
-        required: false
-        type: string
-      gov1_address:
-        description: 'gov1 account address'
-        required: false
-        type: string
-      gov2_mnemonic:
-        description: 'Mnemonic for gov2 wallet'
-        required: false
-        type: string
-      gov2_address:
-        description: 'gov2 account address'
-        required: false
-        type: string
       base_image:
         description: 'Base image tag for agoric-sdk'
         required: false
@@ -93,9 +77,5 @@ jobs:
       bidder_address: ${{ inputs.bidder_address }}
       base_image: ${{ inputs.base_image || 'latest' }}
       a3p_image_tag: ${{ inputs.a3p_image_tag || 'latest' }}
-      gov1_mnemonic: ${{ inputs.gov1_mnemonic }}
-      gov1_address: ${{ inputs.gov1_address }}
-      gov2_mnemonic: ${{ inputs.gov2_mnemonic }}
-      gov2_address: ${{ inputs.gov2_address }}
 
     secrets: inherit

--- a/.github/workflows/liquidation-reconstitution.yml
+++ b/.github/workflows/liquidation-reconstitution.yml
@@ -53,6 +53,10 @@ on:
         required: false
         default: latest
         type: string
+      a3p_image_tag:
+        description: 'Docker image tag for the a3p chain to use in testing'
+        required: false
+        type: string
   pull_request:
     types:
       - labeled
@@ -88,6 +92,7 @@ jobs:
       bidder_mnemonic: ${{ inputs.bidder_mnemonic }}
       bidder_address: ${{ inputs.bidder_address }}
       base_image: ${{ inputs.base_image || 'latest' }}
+      a3p_image_tag: ${{ inputs.a3p_image_tag || 'latest' }}
       gov1_mnemonic: ${{ inputs.gov1_mnemonic }}
       gov1_address: ${{ inputs.gov1_address }}
       gov2_mnemonic: ${{ inputs.gov2_mnemonic }}

--- a/.github/workflows/liquidation.yml
+++ b/.github/workflows/liquidation.yml
@@ -32,22 +32,6 @@ on:
         description: 'bidder account address'
         required: false
         type: string
-      gov1_mnemonic:
-        description: 'Mnemonic for gov1 wallet'
-        required: false
-        type: string
-      gov1_address:
-        description: 'gov1 account address'
-        required: false
-        type: string
-      gov2_mnemonic:
-        description: 'Mnemonic for gov2 wallet'
-        required: false
-        type: string
-      gov2_address:
-        description: 'gov2 account address'
-        required: false
-        type: string
       base_image:
         description: 'Base image tag for agoric-sdk'
         required: false
@@ -93,9 +77,5 @@ jobs:
       bidder_address: ${{ inputs.bidder_address }}
       base_image: ${{ inputs.base_image || 'latest' }}
       a3p_image_tag: ${{ inputs.a3p_image_tag || 'latest' }}
-      gov1_mnemonic: ${{ inputs.gov1_mnemonic }}
-      gov1_address: ${{ inputs.gov1_address }}
-      gov2_mnemonic: ${{ inputs.gov2_mnemonic }}
-      gov2_address: ${{ inputs.gov2_address }}
 
     secrets: inherit

--- a/.github/workflows/liquidation.yml
+++ b/.github/workflows/liquidation.yml
@@ -53,6 +53,10 @@ on:
         required: false
         default: latest
         type: string
+      a3p_image_tag:
+        description: 'Docker image tag for the a3p chain to use in testing'
+        required: false
+        type: string
   pull_request:
     types:
       - labeled
@@ -88,6 +92,7 @@ jobs:
       bidder_mnemonic: ${{ inputs.bidder_mnemonic }}
       bidder_address: ${{ inputs.bidder_address }}
       base_image: ${{ inputs.base_image || 'latest' }}
+      a3p_image_tag: ${{ inputs.a3p_image_tag || 'latest' }}
       gov1_mnemonic: ${{ inputs.gov1_mnemonic }}
       gov1_address: ${{ inputs.gov1_address }}
       gov2_mnemonic: ${{ inputs.gov2_mnemonic }}

--- a/.github/workflows/reusable-workflow.yml
+++ b/.github/workflows/reusable-workflow.yml
@@ -51,6 +51,10 @@ on:
         description: 'gov2 account address'
         required: false
         type: string
+      a3p_image_tag:
+        description: 'Docker image tag for the a3p chain to use in testing'
+        required: false
+        type: string
 
 jobs:
   e2e:
@@ -78,6 +82,7 @@ jobs:
           SYNPRESS_PROFILE: ${{ inputs.AGORIC_NET == 'local' && 'synpress' || 'daily-tests' }}
           CYPRESS_AGORIC_NET: ${{ inputs.AGORIC_NET }}
           # for docker-compose.yml
+          A3P_IMAGE_TAG: ${{ inputs.a3p_image_tag }}
           COMPOSE_DOCKER_CLI_BUILD: 1
           DOCKER_BUILDKIT: 1
           DOCKER_DEFAULT_PLATFORM: linux/amd64

--- a/.github/workflows/reusable-workflow.yml
+++ b/.github/workflows/reusable-workflow.yml
@@ -35,22 +35,6 @@ on:
         required: false
         default: latest
         type: string
-      gov1_mnemonic:
-        description: 'Mnemonic for gov1 wallet'
-        required: false
-        type: string
-      gov1_address:
-        description: 'gov1 account address'
-        required: false
-        type: string
-      gov2_mnemonic:
-        description: 'Mnemonic for gov2 wallet'
-        required: false
-        type: string
-      gov2_address:
-        description: 'gov2 account address'
-        required: false
-        type: string
       a3p_image_tag:
         description: 'Docker image tag for the a3p chain to use in testing'
         required: false
@@ -100,14 +84,14 @@ jobs:
           CYPRESS_MNEMONIC_PHRASE: ${{ inputs.mnemonic_phrase }}
           BASE_IMAGE_TAG_INPUT: ${{ inputs.base_image }}
           # Liquidation Secrets
-          CYPRESS_GOV1_MNEMONIC: ${{ inputs.gov1_mnemonic || secrets.CYPRESS_GOV1_MNEMONIC }}
-          CYPRESS_GOV1_ADDRESS: ${{ inputs.gov1_address || secrets.CYPRESS_GOV1_ADDRESS }}
-          CYPRESS_GOV2_MNEMONIC: ${{ inputs.gov2_mnemonic || secrets.CYPRESS_GOV2_MNEMONIC }}
-          CYPRESS_GOV2_ADDRESS: ${{ inputs.gov2_address || secrets.CYPRESS_GOV2_ADDRESS }}
-          CYPRESS_USER1_MNEMONIC: ${{ inputs.user1_mnemonic || secrets.CYPRESS_USER1_MNEMONIC }}
-          CYPRESS_USER1_ADDRESS: ${{ inputs.user1_address || secrets.CYPRESS_USER1_ADDRESS }}
-          CYPRESS_BIDDER_MNEMONIC: ${{ inputs.bidder_mnemonic || secrets.CYPRESS_BIDDER1_MNEMONIC }}
-          CYPRESS_BIDDER_ADDRESS: ${{ inputs.bidder_address || secrets.CYPRESS_BIDDER1_ADDRESS }}
+          CYPRESS_GOV1_MNEMONIC: ${{ secrets.CYPRESS_GOV1_MNEMONIC }}
+          CYPRESS_GOV1_ADDRESS: ${{ secrets.CYPRESS_GOV1_ADDRESS }}
+          CYPRESS_GOV2_MNEMONIC: ${{ secrets.CYPRESS_GOV2_MNEMONIC }}
+          CYPRESS_GOV2_ADDRESS: ${{ secrets.CYPRESS_GOV2_ADDRESS }}
+          CYPRESS_USER1_MNEMONIC: ${{ secrets.CYPRESS_USER1_MNEMONIC }}
+          CYPRESS_USER1_ADDRESS: ${{ secrets.CYPRESS_USER1_ADDRESS }}
+          CYPRESS_BIDDER_MNEMONIC: ${{ secrets.CYPRESS_BIDDER1_MNEMONIC }}
+          CYPRESS_BIDDER_ADDRESS: ${{ secrets.CYPRESS_BIDDER1_ADDRESS }}
 
       - name: Upload e2e artifacts as workflow artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/vaults.yml
+++ b/.github/workflows/vaults.yml
@@ -30,6 +30,10 @@ on:
         description: 'The mnemonic phrase for the account to use in testing'
         required: false
         type: string
+      a3p_image_tag:
+        description: 'Docker image tag for the a3p chain to use in testing'
+        required: false
+        type: string
 
 concurrency:
   group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'
@@ -53,5 +57,6 @@ jobs:
             || 'local' 
         }}
       mnemonic_phrase: ${{ inputs.phrase }}
+      a3p_image_tag: ${{ inputs.a3p_image_tag || 'latest' }}
 
     secrets: inherit

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ recommended that you use the environment variable `VITE_NETWORK_CONFIG_URL` to p
 VITE_NETWORK_CONFIG_URL=https://<PRODUCTION-NETWORK>.net/network-config yarn build
 ```
 
-# Testing
+# E2E Testing
 
 End-to-end (E2E) tests have been written to test the dapp and perform automated testing on emerynet/devnet during upgrades.
 

--- a/test/e2e/docker-compose-base.yml
+++ b/test/e2e/docker-compose-base.yml
@@ -99,7 +99,7 @@ services:
     profiles:
       - synpress
     container_name: agoric_chain
-    image: ghcr.io/agoric/agoric-3-proposals:latest
+    image: ghcr.io/agoric/agoric-3-proposals:${A3P_IMAGE_TAG}
     logging:
       driver: none
     platform: linux/amd64


### PR DESCRIPTION
The PR does the following:
- Adding support to test the a3p chain with custom tags.
- Removes the input of governance wallets in ci.