### PR TITLE
fix: run liquidation scheduled e2e tests with a3p

### DIFF
--- a/.github/workflows/liquidation-reconstitution.yml
+++ b/.github/workflows/liquidation-reconstitution.yml
@@ -68,7 +68,7 @@ jobs:
             || contains(github.event.pull_request.labels.*.name, 'devnet') && 'devnet' 
             || contains(github.event.pull_request.labels.*.name, 'ollinet') && 'ollinet' 
             || contains(github.event.pull_request.labels.*.name, 'xnet') && 'xnet' 
-            || github.event_name == 'schedule' && 'emerynet' 
+            || github.event_name == 'schedule' && 'local' 
             || 'local' 
         }}
       user1_mnemonic: ${{ inputs.user1_mnemonic }}

--- a/.github/workflows/liquidation.yml
+++ b/.github/workflows/liquidation.yml
@@ -68,7 +68,7 @@ jobs:
             || contains(github.event.pull_request.labels.*.name, 'devnet') && 'devnet' 
             || contains(github.event.pull_request.labels.*.name, 'ollinet') && 'ollinet' 
             || contains(github.event.pull_request.labels.*.name, 'xnet') && 'xnet' 
-            || github.event_name == 'schedule' && 'emerynet' 
+            || github.event_name == 'schedule' && 'local' 
             || 'local' 
         }}
       user1_mnemonic: ${{ inputs.user1_mnemonic }}


### PR DESCRIPTION
Scheduled liquidation tests are typically run with the a3p chain, but due to recent changes, they were being executed against emerynet. This pull request resolves that issue.