### PR TITLE
changes related to xnet in e2e tests for vaults

### DIFF
--- a/test/e2e/specs/test.spec.js
+++ b/test/e2e/specs/test.spec.js
@@ -42,7 +42,9 @@ describe('Vaults UI Test Cases', () => {
     });
 
     it('should create a new vault and approve the transaction successfully', () => {
-      cy.contains('button', /ATOM/).click();
+      if (AGORIC_NET !== 'xnet') {
+        cy.contains('button', /ATOM/).click();
+      }
 
       cy.contains('ATOM to lock up *')
         .next()

--- a/test/e2e/specs/test.spec.js
+++ b/test/e2e/specs/test.spec.js
@@ -15,6 +15,12 @@ describe('Vaults UI Test Cases', () => {
           secretWords: mnemonics.user1,
           walletName: 'user1',
         });
+      } else if (AGORIC_NET === 'xnet') {
+        cy.task('info', 'Connecting with wallet...');
+        cy.setupWallet({
+          secretWords: Cypress.env('USER1_MNEMONIC'),
+          walletName: 'user1',
+        });
       } else {
         cy.setupWallet({
           createNewWallet: true,


### PR DESCRIPTION
Usually, when we create a new wallet on `emerynet`, we manually obtain testnet tokens from the faucet, which gives us enough ATOMs to perform e2e tests of vaults. However, this isn't the case with `xnet`. In this PR, for `xnet`, we've opted to use a custom wallet that comes with a sufficient amount of ATOMs to ensure the e2e tests of vaults function correctly.