### PR TITLE
Check if there are any changes on remote before syncing

### DIFF
--- a/.github/workflows/upstream-sync.yml
+++ b/.github/workflows/upstream-sync.yml
@@ -50,12 +50,29 @@ jobs:
         if: env.HAS_UPSTREAM == 'true' && env.HAS_SYNC_BRANCH == 'true'
         run: git remote add upstream ${{ env.UPSTREAM_URL }}
 
-      - name: Fetch all branches from the upstream repository
+      - name: Check for differences between local and upstream branch, excluding .github/workflows
         if: env.HAS_UPSTREAM == 'true' && env.HAS_SYNC_BRANCH == 'true'
+        run: |
+          git fetch upstream
+          git fetch origin
+
+          # Check if the branch exists on the remote
+          if git show-ref --verify --quiet refs/remotes/origin/${{ env.UPSTREAM_SYNC_BRANCH_NAME }}; then
+            echo "Branch ${{ env.UPSTREAM_SYNC_BRANCH_NAME }} exists on remote."
+            # Compare origin branch with upstream, excluding .github/workflows
+            git diff --quiet origin/${{ env.UPSTREAM_SYNC_BRANCH_NAME }} upstream/main -- . ':(exclude).github/workflows' || echo "CHANGES_DETECTED=true" >> $GITHUB_ENV
+          else
+            echo "Branch ${{ env.UPSTREAM_SYNC_BRANCH_NAME }} does not exist on remote."
+            # Compare upstream/main with itself to force no changes
+            git diff --quiet upstream/main upstream/main -- . ':(exclude).github/workflows' || echo "CHANGES_DETECTED=false" >> $GITHUB_ENV
+          fi
+
+      - name: Fetch all branches from the upstream repository
+        if: env.HAS_UPSTREAM == 'true' && env.HAS_SYNC_BRANCH == 'true' && env.CHANGES_DETECTED == 'true'
         run: git fetch upstream
 
       - name: Set up authentication
-        if: env.HAS_UPSTREAM == 'true' && env.HAS_SYNC_BRANCH == 'true'
+        if: env.HAS_UPSTREAM == 'true' && env.HAS_SYNC_BRANCH == 'true' && env.CHANGES_DETECTED == 'true'
         run: |
           git remote set-url origin https://${{ github.actor }}:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}
         env:
@@ -63,7 +80,7 @@ jobs:
           GITHUB_ACTOR: ${{ github.actor }}
 
       - name: Merge upstream/main into forked repo branch
-        if: env.HAS_UPSTREAM == 'true' && env.HAS_SYNC_BRANCH == 'true'
+        if: env.HAS_UPSTREAM == 'true' && env.HAS_SYNC_BRANCH == 'true' && env.CHANGES_DETECTED == 'true'
         run: |
           git checkout -B ${{ env.UPSTREAM_SYNC_BRANCH_NAME }} upstream/main
 


### PR DESCRIPTION
After we included the change to always push a commit removing changes to the workflow file, this caused the sync to always push a change to the deploy branch, even when there were none. To fix this, we'll check the diff between the remote and origin before attempting to sync.

Action run showing skipping of steps if there are no detected changes
<img width="776" alt="Screenshot 2024-08-27 at 1 06 16 PM" src="https://github.com/user-attachments/assets/9519ff87-82c8-40df-9b4b-6a195429f19b">