### PR TITLE
ci: image parameterization via env variables

### DIFF
--- a/.github/workflows/liquidation-reconstitution.yml
+++ b/.github/workflows/liquidation-reconstitution.yml
@@ -37,8 +37,8 @@ on:
         required: false
         default: latest
         type: string
-      a3p_image_tag:
-        description: 'Docker image tag for the a3p chain to use in testing'
+      docker_image:
+        description: 'Docker image for the a3p chain to use in testing'
         required: false
         type: string
   pull_request:
@@ -76,6 +76,6 @@ jobs:
       bidder_mnemonic: ${{ inputs.bidder_mnemonic }}
       bidder_address: ${{ inputs.bidder_address }}
       base_image: ${{ inputs.base_image || 'latest' }}
-      a3p_image_tag: ${{ inputs.a3p_image_tag || 'latest' }}
+      docker_image: ${{ inputs.docker_image }}
 
     secrets: inherit

--- a/.github/workflows/liquidation-reconstitution.yml
+++ b/.github/workflows/liquidation-reconstitution.yml
@@ -76,6 +76,6 @@ jobs:
       bidder_mnemonic: ${{ inputs.bidder_mnemonic }}
       bidder_address: ${{ inputs.bidder_address }}
       base_image: ${{ inputs.base_image || 'latest' }}
-      docker_image: ${{ inputs.docker_image }}
+      docker_image: ${{ inputs.docker_image || 'ghcr.io/agoric/agoric-3-proposals:latest' }}
 
     secrets: inherit

--- a/.github/workflows/liquidation.yml
+++ b/.github/workflows/liquidation.yml
@@ -37,8 +37,8 @@ on:
         required: false
         default: latest
         type: string
-      a3p_image_tag:
-        description: 'Docker image tag for the a3p chain to use in testing'
+      docker_image:
+        description: 'Docker image for the a3p chain to use in testing'
         required: false
         type: string
   pull_request:
@@ -76,6 +76,6 @@ jobs:
       bidder_mnemonic: ${{ inputs.bidder_mnemonic }}
       bidder_address: ${{ inputs.bidder_address }}
       base_image: ${{ inputs.base_image || 'latest' }}
-      a3p_image_tag: ${{ inputs.a3p_image_tag || 'latest' }}
+      docker_image: ${{ inputs.docker_image }}
 
     secrets: inherit

--- a/.github/workflows/liquidation.yml
+++ b/.github/workflows/liquidation.yml
@@ -76,6 +76,6 @@ jobs:
       bidder_mnemonic: ${{ inputs.bidder_mnemonic }}
       bidder_address: ${{ inputs.bidder_address }}
       base_image: ${{ inputs.base_image || 'latest' }}
-      docker_image: ${{ inputs.docker_image }}
+      docker_image: ${{ inputs.docker_image || 'ghcr.io/agoric/agoric-3-proposals:latest' }}
 
     secrets: inherit

--- a/.github/workflows/reusable-workflow.yml
+++ b/.github/workflows/reusable-workflow.yml
@@ -38,7 +38,6 @@ on:
       docker_image:
         description: 'Docker image for the a3p chain to use in testing'
         required: false
-        default: ghcr.io/agoric/agoric-3-proposals:latest
         type: string
 
 jobs:
@@ -59,6 +58,15 @@ jobs:
         with:
           project_id: 'simulationlab'
           workload_identity_provider: 'projects/60745596728/locations/global/workloadIdentityPools/github/providers/dapp-inter'
+
+      - name: Docker Image Used For E2E Testing
+        run: |
+          if [ -z "${{ inputs.docker_image }}" ]; then
+            echo "Error: Docker image not provided."
+            exit 1
+          else
+            echo "Docker Image: ${{ inputs.docker_image }}"
+          fi
 
       - name: Run e2e tests
         run: ${{ inputs.docker_compose_command }}

--- a/.github/workflows/reusable-workflow.yml
+++ b/.github/workflows/reusable-workflow.yml
@@ -35,9 +35,10 @@ on:
         required: false
         default: latest
         type: string
-      a3p_image_tag:
-        description: 'Docker image tag for the a3p chain to use in testing'
+      docker_image:
+        description: 'Docker image for the a3p chain to use in testing'
         required: false
+        default: ghcr.io/agoric/agoric-3-proposals:latest
         type: string
 
 jobs:
@@ -66,7 +67,7 @@ jobs:
           SYNPRESS_PROFILE: ${{ inputs.AGORIC_NET == 'local' && 'synpress' || 'daily-tests' }}
           CYPRESS_AGORIC_NET: ${{ inputs.AGORIC_NET }}
           # for docker-compose.yml
-          A3P_IMAGE_TAG: ${{ inputs.a3p_image_tag }}
+          DOCKER_IMAGE: ${{ inputs.docker_image }}
           COMPOSE_DOCKER_CLI_BUILD: 1
           DOCKER_BUILDKIT: 1
           DOCKER_DEFAULT_PLATFORM: linux/amd64

--- a/.github/workflows/vaults.yml
+++ b/.github/workflows/vaults.yml
@@ -57,6 +57,6 @@ jobs:
             || 'local' 
         }}
       mnemonic_phrase: ${{ inputs.phrase }}
-      docker_image: ${{ inputs.docker_image || 'latest' }}
+      docker_image: ${{ inputs.docker_image || 'ghcr.io/agoric/agoric-3-proposals:latest' }}
 
     secrets: inherit

--- a/.github/workflows/vaults.yml
+++ b/.github/workflows/vaults.yml
@@ -30,8 +30,8 @@ on:
         description: 'The mnemonic phrase for the account to use in testing'
         required: false
         type: string
-      a3p_image_tag:
-        description: 'Docker image tag for the a3p chain to use in testing'
+      docker_image:
+        description: 'Docker image for the a3p chain to use in testing'
         required: false
         type: string
 
@@ -57,6 +57,6 @@ jobs:
             || 'local' 
         }}
       mnemonic_phrase: ${{ inputs.phrase }}
-      a3p_image_tag: ${{ inputs.a3p_image_tag || 'latest' }}
+      docker_image: ${{ inputs.docker_image || 'latest' }}
 
     secrets: inherit

--- a/test/e2e/docker-compose-base.yml
+++ b/test/e2e/docker-compose-base.yml
@@ -99,7 +99,7 @@ services:
     profiles:
       - synpress
     container_name: agoric_chain
-    image: ghcr.io/agoric/agoric-3-proposals:${A3P_IMAGE_TAG}
+    image: ${DOCKER_IMAGE}
     logging:
       driver: none
     platform: linux/amd64


### PR DESCRIPTION
This PR introduces the ability to input a custom image name for E2E testing.

#### Previous Setup:
- Previously, we used the image `ghcr.io/agoric/agoric-3-proposals` for E2E testing.
- We could specify the `tag` for this image during testing in CI via an input.

#### The Issue:
- Recently, images like `ghcr.io/agoric/agoric-sdk:a3p-use-upgrade-next-20240911203722-bc66a5` started being used for E2E testing, in `u17`.
- To test this image in CI, we manually hardcoded the image name in the `docker-compose` file (as done in #365). This was not ideal.