### PR TITLE
test: fix and structure tests related to auction

### DIFF
--- a/test/e2e/specs/liquidation.spec.js
+++ b/test/e2e/specs/liquidation.spec.js
@@ -439,14 +439,17 @@ describe('Wallet App Test Cases', () => {
 
       if (AGORIC_NET === networks.LOCAL) {
         const expectedValue = 9.99;
+        cy.task('info', `Expected Value: ${expectedValue}`);
         cy.fetchVStorageData({
           url: auctionURL,
           field: 'startPrice',
         }).then(data => {
-          cy.calculateRatios(data, { hasDenom: true }).then(result => {
-            const valueFound = result.find(item => item === expectedValue);
-            expect(valueFound).to.be.true;
-          });
+          cy.calculateRatios(data, { hasDenom: true, useValue: false }).then(
+            result => {
+              const valueFound = result.includes(expectedValue);
+              expect(valueFound).to.be.true;
+            },
+          );
         });
       } else {
         const propertyName = 'book0.startPrice';
@@ -458,14 +461,17 @@ describe('Wallet App Test Cases', () => {
     it('should verify the value of startProceedsGoal', () => {
       if (AGORIC_NET === networks.LOCAL) {
         const expectedValue = 309.54;
+        cy.task('info', `Expected Value: ${expectedValue}`);
         cy.fetchVStorageData({
           url: auctionURL,
           field: 'startProceedsGoal',
         }).then(data => {
-          cy.calculateRatios(data, { hasDenom: false }).then(result => {
-            const valueFound = result.find(item => item === expectedValue);
-            expect(valueFound).to.be.true;
-          });
+          cy.calculateRatios(data, { hasDenom: false, useValue: true }).then(
+            result => {
+              const valueFound = result.includes(expectedValue);
+              expect(valueFound).to.be.true;
+            },
+          );
         });
       } else {
         const propertyName = 'book0.startProceedsGoal';
@@ -477,14 +483,17 @@ describe('Wallet App Test Cases', () => {
     it('should verify the value of startCollateral', () => {
       if (AGORIC_NET === networks.LOCAL) {
         const expectedValue = 45;
+        cy.task('info', `Expected Value: ${expectedValue}`);
         cy.fetchVStorageData({
           url: auctionURL,
           field: 'startCollateral',
         }).then(data => {
-          cy.calculateRatios(data, { hasDenom: false }).then(result => {
-            const valueFound = result.find(item => item === expectedValue);
-            expect(valueFound).to.be.true;
-          });
+          cy.calculateRatios(data, { hasDenom: false, useValue: true }).then(
+            result => {
+              const valueFound = result.includes(expectedValue);
+              expect(valueFound).to.be.true;
+            },
+          );
         });
       } else {
         const propertyName = 'book0.startCollateral';
@@ -516,14 +525,17 @@ describe('Wallet App Test Cases', () => {
 
       if (AGORIC_NET === networks.LOCAL) {
         const expectedValue = 9.659301;
+        cy.task('info', `Expected Value: ${expectedValue}`);
         cy.fetchVStorageData({
           url: auctionURL,
           field: 'collateralAvailable',
         }).then(data => {
-          cy.calculateRatios(data, { hasDenom: false }).then(result => {
-            const valueFound = result.find(item => item === expectedValue);
-            expect(valueFound).to.be.true;
-          });
+          cy.calculateRatios(data, { hasDenom: false, useValue: true }).then(
+            result => {
+              const valueFound = result.includes(expectedValue);
+              expect(valueFound).to.be.true;
+            },
+          );
         });
       } else {
         const propertyName = 'book0.collateralAvailable';
@@ -533,112 +545,115 @@ describe('Wallet App Test Cases', () => {
     });
   });
 
-  context('Close the vaults and cancel bids - TESTNET(s)', () => {
-    it('should claim collateral from the first vault successfully', () => {
-      cy.skipWhen(AGORIC_NET === networks.LOCAL);
+  context(
+    'Claim collateral from vaults, restore ATOM price to 12.34, and cancel bids on TESTNET(s).',
+    () => {
+      it('should claim collateral from the first vault successfully', () => {
+        cy.skipWhen(AGORIC_NET === networks.LOCAL);
 
-      cy.contains(/3.42 ATOM/, { timeout: MINUTE_MS }).click();
-      cy.contains('button', 'Close Out Vault').click();
-      cy.wait(MINUTE_MS);
-      cy.acceptAccess().then(taskCompleted => {
-        expect(taskCompleted).to.be.true;
-        cy.contains('button', 'Close Out Vault', {
-          timeout: DEFAULT_TIMEOUT,
-        }).should('not.exist');
-      });
-    });
-
-    it('should claim collateral from the second vault successfully', () => {
-      cy.skipWhen(AGORIC_NET === networks.LOCAL);
-
-      cy.contains(/3.07 ATOM/, { timeout: MINUTE_MS }).click();
-      cy.contains('button', 'Close Out Vault').click();
-      cy.wait(MINUTE_MS);
-      cy.acceptAccess().then(taskCompleted => {
-        expect(taskCompleted).to.be.true;
-        cy.contains('button', 'Close Out Vault', {
-          timeout: DEFAULT_TIMEOUT,
-        }).should('not.exist');
-      });
-    });
-
-    it('should claim collateral from the third vault successfully', () => {
-      cy.skipWhen(AGORIC_NET === networks.LOCAL);
-
-      cy.contains(/2.84 ATOM/, { timeout: MINUTE_MS }).click();
-      cy.contains('button', 'Close Out Vault').click();
-      cy.wait(MINUTE_MS);
-      cy.acceptAccess().then(taskCompleted => {
-        expect(taskCompleted).to.be.true;
-        cy.contains('button', 'Close Out Vault', {
-          timeout: DEFAULT_TIMEOUT,
-        }).should('not.exist');
-      });
-    });
-
-    it('should set ATOM price back to 12.34', () => {
-      cy.skipWhen(AGORIC_NET === networks.LOCAL);
-      cy.setOraclePrice(12.34);
-    });
-
-    it('should switch to the bidder wallet successfully', () => {
-      cy.skipWhen(AGORIC_NET === networks.LOCAL);
-      cy.switchWallet(bidderWalletName);
-    });
-
-    it('should setup the web wallet and cancel the 150IST bid', () => {
-      cy.skipWhen(AGORIC_NET === networks.LOCAL);
-
-      cy.visit(webWalletURL);
-
-      cy.acceptAccess().then(taskCompleted => {
-        expect(taskCompleted).to.be.true;
-      });
-
-      cy.visit(`${webWalletURL}/wallet/`);
-
-      cy.get('input[type="checkbox"]').check();
-      cy.contains('Proceed').click();
-      cy.get('button[aria-label="Settings"]').click();
-
-      cy.contains('div', 'Mainnet').click();
-      cy.contains('li', webWalletSelectors[AGORIC_NET]).click();
-      cy.contains('button', 'Connect').click();
-
-      cy.acceptAccess().then(taskCompleted => {
-        expect(taskCompleted).to.be.true;
-      });
-
-      cy.reload();
-
-      cy.get('span')
-        .contains('ATOM', { timeout: DEFAULT_TIMEOUT })
-        .should('exist');
-      cy.get('span')
-        .contains('BLD', { timeout: DEFAULT_TIMEOUT })
-        .should('exist');
-
-      // Verify completely filled bids
-      cy.contains('90.00 IST', { timeout: DEFAULT_TIMEOUT }).should(
-        'not.exist',
-      );
-      cy.contains('80.00 IST', { timeout: DEFAULT_TIMEOUT }).should(
-        'not.exist',
-      );
-      // Verify 150 IST Bid to exist
-      cy.contains('150.00 IST', { timeout: DEFAULT_TIMEOUT }).should('exist');
-
-      cy.getTokenAmount('IST').then(initialTokenValue => {
-        cy.contains('Exit').click();
+        cy.contains(/3.42 ATOM/, { timeout: MINUTE_MS }).click();
+        cy.contains('button', 'Close Out Vault').click();
         cy.wait(MINUTE_MS);
         cy.acceptAccess().then(taskCompleted => {
           expect(taskCompleted).to.be.true;
-        });
-        cy.contains('Accepted', { timeout: DEFAULT_TIMEOUT }).should('exist');
-        cy.getTokenAmount('IST').then(tokenValue => {
-          expect(tokenValue).to.greaterThan(initialTokenValue);
+          cy.contains('button', 'Close Out Vault', {
+            timeout: DEFAULT_TIMEOUT,
+          }).should('not.exist');
         });
       });
-    });
-  });
+
+      it('should claim collateral from the second vault successfully', () => {
+        cy.skipWhen(AGORIC_NET === networks.LOCAL);
+
+        cy.contains(/3.07 ATOM/, { timeout: MINUTE_MS }).click();
+        cy.contains('button', 'Close Out Vault').click();
+        cy.wait(MINUTE_MS);
+        cy.acceptAccess().then(taskCompleted => {
+          expect(taskCompleted).to.be.true;
+          cy.contains('button', 'Close Out Vault', {
+            timeout: DEFAULT_TIMEOUT,
+          }).should('not.exist');
+        });
+      });
+
+      it('should claim collateral from the third vault successfully', () => {
+        cy.skipWhen(AGORIC_NET === networks.LOCAL);
+
+        cy.contains(/2.84 ATOM/, { timeout: MINUTE_MS }).click();
+        cy.contains('button', 'Close Out Vault').click();
+        cy.wait(MINUTE_MS);
+        cy.acceptAccess().then(taskCompleted => {
+          expect(taskCompleted).to.be.true;
+          cy.contains('button', 'Close Out Vault', {
+            timeout: DEFAULT_TIMEOUT,
+          }).should('not.exist');
+        });
+      });
+
+      it('should set ATOM price back to 12.34', () => {
+        cy.skipWhen(AGORIC_NET === networks.LOCAL);
+        cy.setOraclePrice(12.34);
+      });
+
+      it('should switch to the bidder wallet successfully', () => {
+        cy.skipWhen(AGORIC_NET === networks.LOCAL);
+        cy.switchWallet(bidderWalletName);
+      });
+
+      it('should setup the web wallet and cancel the 150IST bid', () => {
+        cy.skipWhen(AGORIC_NET === networks.LOCAL);
+
+        cy.visit(webWalletURL);
+
+        cy.acceptAccess().then(taskCompleted => {
+          expect(taskCompleted).to.be.true;
+        });
+
+        cy.visit(`${webWalletURL}/wallet/`);
+
+        cy.get('input[type="checkbox"]').check();
+        cy.contains('Proceed').click();
+        cy.get('button[aria-label="Settings"]').click();
+
+        cy.contains('div', 'Mainnet').click();
+        cy.contains('li', webWalletSelectors[AGORIC_NET]).click();
+        cy.contains('button', 'Connect').click();
+
+        cy.acceptAccess().then(taskCompleted => {
+          expect(taskCompleted).to.be.true;
+        });
+
+        cy.reload();
+
+        cy.get('span')
+          .contains('ATOM', { timeout: DEFAULT_TIMEOUT })
+          .should('exist');
+        cy.get('span')
+          .contains('BLD', { timeout: DEFAULT_TIMEOUT })
+          .should('exist');
+
+        // Verify completely filled bids
+        cy.contains('90.00 IST', { timeout: DEFAULT_TIMEOUT }).should(
+          'not.exist',
+        );
+        cy.contains('80.00 IST', { timeout: DEFAULT_TIMEOUT }).should(
+          'not.exist',
+        );
+        // Verify 150 IST Bid to exist
+        cy.contains('150.00 IST', { timeout: DEFAULT_TIMEOUT }).should('exist');
+
+        cy.getTokenAmount('IST').then(initialTokenValue => {
+          cy.contains('Exit').click();
+          cy.wait(MINUTE_MS);
+          cy.acceptAccess().then(taskCompleted => {
+            expect(taskCompleted).to.be.true;
+          });
+          cy.contains('Accepted', { timeout: DEFAULT_TIMEOUT }).should('exist');
+          cy.getTokenAmount('IST').then(tokenValue => {
+            expect(tokenValue).to.greaterThan(initialTokenValue);
+          });
+        });
+      });
+    },
+  );
 });

--- a/test/e2e/support.js
+++ b/test/e2e/support.js
@@ -218,7 +218,7 @@ Cypress.Commands.add('fetchVStorageData', params => {
     cy.task('info', `Data fetched successfully for ${field}`);
 
     const data = JSON.parse(response.body.value);
-    cy.task('info', `VStorage Data: ${data}`);
+    cy.task('info', `VStorage Data: ${JSON.stringify(data)}`);
 
     const arr = data.values.map((value, _) => {
       const parsedValue = JSON.parse(value);
@@ -226,28 +226,35 @@ Cypress.Commands.add('fetchVStorageData', params => {
       return body[`${field}`];
     });
 
-    cy.task('info', `Filtered Data: ${arr}`);
-    return arr;
+    cy.task('info', `Filtered Data: ${JSON.stringify(arr)}`);
+    cy.wrap(arr);
   });
 });
 
 Cypress.Commands.add(
   'calculateRatios',
-  (data, options = { hasDenom: true }) => {
-    return data.map(item => {
-      if (item !== null && item !== undefined) {
-        const numerValue = Number(item.numerator.value.replace('+', ''));
+  (data, options = { hasDenom: true, useValue: false }) => {
+    cy.wrap(
+      data.map(item => {
+        if (item !== null && item !== undefined) {
+          const numerValue = options.useValue
+            ? Number(item.value.replace('+', ''))
+            : item.numerator
+              ? Number(item.numerator.value.replace('+', ''))
+              : 0;
 
-        const denomValue = options.hasDenom
-          ? Number(item.denominator.value.replace('+', ''))
-          : 1_000_000;
+          const denomValue =
+            options.hasDenom && item.denominator
+              ? Number(item.denominator.value.replace('+', ''))
+              : 1_000_000;
 
-        const ratio = numerValue / denomValue;
-        return ratio;
-      }
+          const ratio = numerValue / denomValue;
+          return ratio;
+        }
 
-      return item;
-    });
+        return item;
+      }),
+    );
   },
 );
 

--- a/test/e2e/test.utils.js
+++ b/test/e2e/test.utils.js
@@ -51,6 +51,7 @@ export const configMap = {
     gov2Address: Cypress.env('GOV2_ADDRESS'),
     gov2WalletName: 'gov2',
     econGovURL: `https://econ-gov.inter.trade/?agoricNet=${Cypress.env('AGORIC_NET')}`,
+    auctionURL: `https://${Cypress.env('AGORIC_NET')?.trim()}.api.agoric.net/agoric/vstorage/data/published.auction.book0`,
   },
   local: {
     DEFAULT_TIMEOUT: 1 * 60 * 1000,
@@ -70,6 +71,8 @@ export const configMap = {
     gov2Address: accountAddresses.gov2,
     gov2WalletName: 'gov2',
     econGovURL: 'https://econ-gov.inter.trade/?agoricNet=local',
+    auctionURL:
+      'http://localhost:1317/agoric/vstorage/data/published.auction.book0',
   },
 };
 


### PR DESCRIPTION
closes [#216](https://github.com/Agoric/agoric-private/issues/216)

This PR includes the following updates:

- Adds a custom command to get data from VStorage.
- Uses this command to get Auction data.

The old auction instance overwrites new auction instance values, so for A3P testing, I now get auction data from VStorage instead of using the `agops inter auction status` command. We’ll still use the `agops` command for testnets, but for A3P tests, VStorage will be the source. After getting the data, the test checks for the right auction values. If found, the test passes. 
