### PR TITLE
dont trigger vault tests on `edited` event

### DIFF
--- a/.github/workflows/vaults.yml
+++ b/.github/workflows/vaults.yml
@@ -8,7 +8,6 @@ on:
     types:
       - opened
       - reopened
-      - edited
       - labeled
       - synchronize
   schedule:


### PR DESCRIPTION
Currently, Vault tests are triggered when someone edits the PR description or makes any changes linked to the edited event in GitHub Actions. This causes the Vault CI workflow to restart even after it has already passed, which is unnecessary.

This PR fixes the issue by removing the edited event from the Vault workflow.