### PR TITLE
Improvements in e2e tests

### DIFF
--- a/test/e2e/specs/liquidation-reconstitution.spec.js
+++ b/test/e2e/specs/liquidation-reconstitution.spec.js
@@ -1,4 +1,12 @@
-import { mnemonics, MINUTE_MS, networks, configMap } from '../test.utils';
+import {
+  mnemonics,
+  MINUTE_MS,
+  networks,
+  configMap,
+  QUICK_WAIT,
+  webWalletURL,
+  webWalletSelectors,
+} from '../test.utils';
 
 describe('Wallet App Test Cases', () => {
   let startTime;
@@ -20,6 +28,7 @@ describe('Wallet App Test Cases', () => {
   const gov2Address = currentConfig.gov2Address;
   const econGovURL = currentConfig.econGovURL;
   const auctionURL = currentConfig.auctionURL;
+  let bidderAtomBalance = 0;
 
   context('Setting up accounts', () => {
     // Using exports from the synthetic-chain lib instead of hardcoding mnemonics UNTIL https://github.com/Agoric/agoric-3-proposals/issues/154
@@ -384,7 +393,7 @@ describe('Wallet App Test Cases', () => {
       });
 
       it('should save bidder ATOM balance before placing bids', () => {
-        cy.wait(MINUTE_MS);
+        cy.wait(QUICK_WAIT);
         cy.getATOMBalance({
           walletAddress: bidderAddress,
         }).then(output => {
@@ -436,7 +445,7 @@ describe('Wallet App Test Cases', () => {
 
   context('Verify auction values while vaults are LIQUIDATING', () => {
     it('should verify the value of startPrice', () => {
-      cy.wait(MINUTE_MS);
+      cy.wait(QUICK_WAIT);
 
       if (AGORIC_NET === networks.LOCAL) {
         const expectedValue = 9.99;
@@ -529,7 +538,7 @@ describe('Wallet App Test Cases', () => {
       );
 
       it('should verify the value of collateralAvailable', () => {
-        cy.wait(MINUTE_MS);
+        cy.wait(QUICK_WAIT);
 
         if (AGORIC_NET === networks.LOCAL) {
           const expectedValue = 31.414987;

--- a/test/e2e/specs/liquidation.spec.js
+++ b/test/e2e/specs/liquidation.spec.js
@@ -5,6 +5,8 @@ import {
   configMap,
   webWalletURL,
   webWalletSelectors,
+  QUICK_WAIT,
+  THIRTY_SECONDS,
 } from '../test.utils';
 
 describe('Wallet App Test Cases', () => {
@@ -381,7 +383,7 @@ describe('Wallet App Test Cases', () => {
     });
 
     it('should save bidder ATOM balance before placing bids', () => {
-      cy.wait(MINUTE_MS);
+      cy.wait(QUICK_WAIT);
       cy.getATOMBalance({
         walletAddress: bidderAddress,
       }).then(output => {
@@ -445,7 +447,7 @@ describe('Wallet App Test Cases', () => {
 
   context('Verify auction values while vaults are LIQUIDATING', () => {
     it('should verify the value of startPrice', () => {
-      cy.wait(MINUTE_MS);
+      cy.wait(THIRTY_SECONDS);
 
       if (AGORIC_NET === networks.LOCAL) {
         const expectedValue = 9.99;
@@ -531,7 +533,7 @@ describe('Wallet App Test Cases', () => {
     );
 
     it('should verify the value of collateralAvailable', () => {
-      cy.wait(MINUTE_MS);
+      cy.wait(QUICK_WAIT);
 
       if (AGORIC_NET === networks.LOCAL) {
         const expectedValue = 9.659301;
@@ -557,7 +559,7 @@ describe('Wallet App Test Cases', () => {
 
   context('Claim collateral from the liquidated vaults', () => {
     it('should save user1 ATOM balance before claiming collateral', () => {
-      cy.wait(MINUTE_MS);
+      cy.wait(QUICK_WAIT);
 
       cy.getATOMBalance({
         walletAddress: user1Address,
@@ -570,7 +572,7 @@ describe('Wallet App Test Cases', () => {
     it('should claim collateral from the first vault successfully', () => {
       cy.contains(/3.42 ATOM/, { timeout: MINUTE_MS }).click();
       cy.contains('button', 'Close Out Vault').click();
-      cy.wait(5000); // eslint-disable-line cypress/no-unnecessary-waiting
+      cy.wait(QUICK_WAIT); // eslint-disable-line cypress/no-unnecessary-waiting
       cy.acceptAccess().then(taskCompleted => {
         expect(taskCompleted).to.be.true;
         cy.contains('button', 'Close Out Vault', {
@@ -582,7 +584,7 @@ describe('Wallet App Test Cases', () => {
     it('should claim collateral from the second vault successfully', () => {
       cy.contains(/3.07 ATOM/, { timeout: MINUTE_MS }).click();
       cy.contains('button', 'Close Out Vault').click();
-      cy.wait(5000); // eslint-disable-line cypress/no-unnecessary-waiting
+      cy.wait(QUICK_WAIT); // eslint-disable-line cypress/no-unnecessary-waiting
       cy.acceptAccess().then(taskCompleted => {
         expect(taskCompleted).to.be.true;
         cy.contains('button', 'Close Out Vault', {
@@ -594,7 +596,7 @@ describe('Wallet App Test Cases', () => {
     it('should claim collateral from the third vault successfully', () => {
       cy.contains(/2.84 ATOM/, { timeout: MINUTE_MS }).click();
       cy.contains('button', 'Close Out Vault').click();
-      cy.wait(5000); // eslint-disable-line cypress/no-unnecessary-waiting
+      cy.wait(QUICK_WAIT); // eslint-disable-line cypress/no-unnecessary-waiting
       cy.acceptAccess().then(taskCompleted => {
         expect(taskCompleted).to.be.true;
         cy.contains('button', 'Close Out Vault', {
@@ -604,7 +606,7 @@ describe('Wallet App Test Cases', () => {
     });
 
     it("should see increase in the user1's ATOM balance after claiming collateral", () => {
-      cy.wait(10000); // eslint-disable-line cypress/no-unnecessary-waiting
+      cy.wait(QUICK_WAIT); // eslint-disable-line cypress/no-unnecessary-waiting
 
       const expectedValue = 9.35;
       cy.task(
@@ -703,7 +705,7 @@ describe('Wallet App Test Cases', () => {
 
       cy.getTokenAmount('IST').then(initialTokenValue => {
         cy.contains('Exit').click();
-        cy.wait(MINUTE_MS);
+        cy.wait(QUICK_WAIT);
         cy.acceptAccess().then(taskCompleted => {
           expect(taskCompleted).to.be.true;
         });
@@ -716,7 +718,7 @@ describe('Wallet App Test Cases', () => {
 
     it('should save bidder ATOM balance', () => {
       cy.skipWhen(AGORIC_NET !== networks.LOCAL);
-      cy.wait(MINUTE_MS);
+      cy.wait(QUICK_WAIT);
       cy.getATOMBalance({
         walletAddress: bidderAddress,
       }).then(output => {
@@ -730,7 +732,7 @@ describe('Wallet App Test Cases', () => {
 
       cy.getTokenAmount('IST').then(initialTokenValue => {
         cy.contains('Exit').click();
-        cy.wait(MINUTE_MS);
+        cy.wait(QUICK_WAIT);
         cy.acceptAccess().then(taskCompleted => {
           expect(taskCompleted).to.be.true;
         });
@@ -742,7 +744,7 @@ describe('Wallet App Test Cases', () => {
     });
 
     it("should see increase in the bidder's ATOM balance because of partially filled bid", () => {
-      cy.wait(10000); // eslint-disable-line cypress/no-unnecessary-waiting
+      cy.wait(QUICK_WAIT); // eslint-disable-line cypress/no-unnecessary-waiting
 
       const expectedValue = 16.43;
       cy.task(

--- a/test/e2e/specs/liquidation.spec.js
+++ b/test/e2e/specs/liquidation.spec.js
@@ -657,7 +657,6 @@ describe('Wallet App Test Cases', () => {
     });
 
     it('should setup the web wallet and cancel the 150IST bid', () => {
-      cy.skipWhen(AGORIC_NET === networks.LOCAL);
       cy.visit(webWalletURL);
 
       cy.acceptAccess().then(taskCompleted => {
@@ -711,7 +710,6 @@ describe('Wallet App Test Cases', () => {
     });
 
     it("should see increase in the bidder's ATOM balance because of partially filled bid", () => {
-      cy.skipWhen(AGORIC_NET === networks.LOCAL);
       cy.wait(10000); // eslint-disable-line cypress/no-unnecessary-waiting
 
       const expectedValue = 16.43;

--- a/test/e2e/specs/liquidation.spec.js
+++ b/test/e2e/specs/liquidation.spec.js
@@ -656,7 +656,7 @@ describe('Wallet App Test Cases', () => {
       cy.switchWallet(bidderWalletName);
     });
 
-    it('should setup the web wallet and cancel the 150IST bid', () => {
+    it('should setup the web wallet', () => {
       cy.visit(webWalletURL);
 
       cy.acceptAccess().then(taskCompleted => {
@@ -695,9 +695,41 @@ describe('Wallet App Test Cases', () => {
       );
       // Verify 150 IST Bid to exist
       cy.contains('150.00 IST', { timeout: DEFAULT_TIMEOUT }).should('exist');
+    });
+
+    it('should cancel the 1IST bid', () => {
+      cy.skipWhen(AGORIC_NET !== networks.LOCAL);
+      cy.reload();
 
       cy.getTokenAmount('IST').then(initialTokenValue => {
-        cy.contains('Exit').eq(1).click();
+        cy.contains('Exit').click();
+        cy.wait(MINUTE_MS);
+        cy.acceptAccess().then(taskCompleted => {
+          expect(taskCompleted).to.be.true;
+        });
+        cy.contains('Accepted', { timeout: DEFAULT_TIMEOUT }).should('exist');
+        cy.getTokenAmount('IST').then(tokenValue => {
+          expect(tokenValue).to.greaterThan(initialTokenValue);
+        });
+      });
+    });
+
+    it('should save bidder ATOM balance', () => {
+      cy.skipWhen(AGORIC_NET !== networks.LOCAL);
+      cy.wait(MINUTE_MS);
+      cy.getATOMBalance({
+        walletAddress: bidderAddress,
+      }).then(output => {
+        bidderAtomBalance = Number(output.toFixed(2));
+        cy.task('info', `bidderAtomBalance: ${bidderAtomBalance}`);
+      });
+    });
+
+    it('should cancel the 150IST bid', () => {
+      cy.reload();
+
+      cy.getTokenAmount('IST').then(initialTokenValue => {
+        cy.contains('Exit').click();
         cy.wait(MINUTE_MS);
         cy.acceptAccess().then(taskCompleted => {
           expect(taskCompleted).to.be.true;

--- a/test/e2e/test.utils.js
+++ b/test/e2e/test.utils.js
@@ -13,6 +13,8 @@ export const accountAddresses = {
 
 export const webWalletURL = 'https://wallet.agoric.app/';
 export const MINUTE_MS = 1 * 60 * 1000;
+export const QUICK_WAIT = 10 * 1000;
+export const THIRTY_SECONDS = 30 * 1000;
 
 export const agoricNetworks = {
   emerynet: 'Agoric Emerynet',


### PR DESCRIPTION
The PR does the following:
- Replicates changes from #373 for liquidation-reconstitution tests, to verify ATOM balance after relevant ATOM transactions. 
- Enables and adds some tests related to canceling of bids - catered for a3p.  
- Adjusting the waiting period before balance checks. Mainly reducing the value. 