### PR TITLE
Improvements when comparing decimal values 

### DIFF
--- a/test/e2e/specs/liquidation-reconstitution.spec.js
+++ b/test/e2e/specs/liquidation-reconstitution.spec.js
@@ -7,6 +7,7 @@ import {
   webWalletURL,
   webWalletSelectors,
   tokens,
+  extractNumber,
 } from '../test.utils';
 
 describe('Wallet App Test Cases', () => {
@@ -483,9 +484,15 @@ describe('Wallet App Test Cases', () => {
           );
         });
       } else {
-        const propertyName = 'book0.startPrice';
+        const propertyName = 'startPrice';
         const expectedValue = '9.99 IST/ATOM';
-        cy.verifyAuctionData(propertyName, expectedValue);
+        cy.task('info', `Expected Value: ${expectedValue}`);
+        cy.getAuctionParam(propertyName).then(value => {
+          const actualValue = extractNumber(value);
+          const expectedValueRounded = extractNumber(expectedValue);
+
+          expect(actualValue).to.eq(expectedValueRounded);
+        });
       }
     });
 
@@ -505,9 +512,21 @@ describe('Wallet App Test Cases', () => {
           );
         });
       } else {
-        const propertyName = 'book0.startProceedsGoal';
+        const propertyName = 'startProceedsGoal';
         const expectedValue = '309.54 IST';
-        cy.verifyAuctionData(propertyName, expectedValue);
+        cy.task('info', `Expected Value: ${expectedValue}`);
+        cy.getAuctionParam(propertyName).then(value => {
+          cy.task(
+            'info',
+            'Comparing actual and expected values rounded to one decimal place.',
+          );
+
+          const actualValue = Math.round(extractNumber(value) * 10) / 10;
+          const expectedValueRounded =
+            Math.round(extractNumber(expectedValue) * 10) / 10;
+
+          expect(actualValue).to.eq(expectedValueRounded);
+        });
       }
     });
 
@@ -527,9 +546,15 @@ describe('Wallet App Test Cases', () => {
           );
         });
       } else {
-        const propertyName = 'book0.startCollateral';
+        const propertyName = 'startCollateral';
         const expectedValue = '45 ATOM';
-        cy.verifyAuctionData(propertyName, expectedValue);
+        cy.task('info', `Expected Value: ${expectedValue}`);
+        cy.getAuctionParam(propertyName).then(value => {
+          const actualValue = extractNumber(value);
+          const expectedValueRounded = extractNumber(expectedValue);
+
+          expect(actualValue).to.eq(expectedValueRounded);
+        });
       }
     });
   });
@@ -576,9 +601,21 @@ describe('Wallet App Test Cases', () => {
             );
           });
         } else {
-          const propertyName = 'book0.collateralAvailable';
+          const propertyName = 'collateralAvailable';
           const expectedValue = '31.414987 ATOM';
-          cy.verifyAuctionData(propertyName, expectedValue); // eslint-disable-line cypress/no-unnecessary-waiting
+          cy.task('info', `Expected Value: ${expectedValue}`);
+          cy.getAuctionParam(propertyName).then(value => {
+            cy.task(
+              'info',
+              'Comparing actual and expected values rounded to one decimal place.',
+            );
+
+            const actualValue = Math.round(extractNumber(value) * 10) / 10;
+            const expectedValueRounded =
+              Math.round(extractNumber(expectedValue) * 10) / 10;
+
+            expect(actualValue).to.eq(expectedValueRounded);
+          });
         }
       });
     },

--- a/test/e2e/specs/liquidation.spec.js
+++ b/test/e2e/specs/liquidation.spec.js
@@ -8,6 +8,7 @@ import {
   QUICK_WAIT,
   THIRTY_SECONDS,
   tokens,
+  extractNumber,
 } from '../test.utils';
 
 describe('Wallet App Test Cases', () => {
@@ -485,9 +486,15 @@ describe('Wallet App Test Cases', () => {
           );
         });
       } else {
-        const propertyName = 'book0.startPrice';
+        const propertyName = 'startPrice';
         const expectedValue = '9.99 IST/ATOM';
-        cy.verifyAuctionData(propertyName, expectedValue);
+        cy.task('info', `Expected Value: ${expectedValue}`);
+        cy.getAuctionParam(propertyName).then(value => {
+          const actualValue = extractNumber(value);
+          const expectedValueRounded = extractNumber(expectedValue);
+
+          expect(actualValue).to.eq(expectedValueRounded);
+        });
       }
     });
 
@@ -507,9 +514,21 @@ describe('Wallet App Test Cases', () => {
           );
         });
       } else {
-        const propertyName = 'book0.startProceedsGoal';
+        const propertyName = 'startProceedsGoal';
         const expectedValue = '309.54 IST';
-        cy.verifyAuctionData(propertyName, expectedValue);
+        cy.task('info', `Expected Value: ${expectedValue}`);
+        cy.getAuctionParam(propertyName).then(value => {
+          cy.task(
+            'info',
+            'Comparing actual and expected values rounded to one decimal place.',
+          );
+
+          const actualValue = Math.round(extractNumber(value) * 10) / 10;
+          const expectedValueRounded =
+            Math.round(extractNumber(expectedValue) * 10) / 10;
+
+          expect(actualValue).to.eq(expectedValueRounded);
+        });
       }
     });
 
@@ -529,9 +548,15 @@ describe('Wallet App Test Cases', () => {
           );
         });
       } else {
-        const propertyName = 'book0.startCollateral';
+        const propertyName = 'startCollateral';
         const expectedValue = '45 ATOM';
-        cy.verifyAuctionData(propertyName, expectedValue);
+        cy.task('info', `Expected Value: ${expectedValue}`);
+        cy.getAuctionParam(propertyName).then(value => {
+          const actualValue = extractNumber(value);
+          const expectedValueRounded = extractNumber(expectedValue);
+
+          expect(actualValue).to.eq(expectedValueRounded);
+        });
       }
     });
   });
@@ -571,9 +596,21 @@ describe('Wallet App Test Cases', () => {
           );
         });
       } else {
-        const propertyName = 'book0.collateralAvailable';
+        const propertyName = 'collateralAvailable';
         const expectedValue = '9.659301 ATOM';
-        cy.verifyAuctionData(propertyName, expectedValue); // eslint-disable-line cypress/no-unnecessary-waiting
+        cy.task('info', `Expected Value: ${expectedValue}`);
+        cy.getAuctionParam(propertyName).then(value => {
+          cy.task(
+            'info',
+            'Comparing actual and expected values rounded to one decimal place.',
+          );
+
+          const actualValue = Math.round(extractNumber(value) * 10) / 10;
+          const expectedValueRounded =
+            Math.round(extractNumber(expectedValue) * 10) / 10;
+
+          expect(actualValue).to.eq(expectedValueRounded);
+        });
       }
     });
   });

--- a/test/e2e/support.js
+++ b/test/e2e/support.js
@@ -15,7 +15,7 @@ const balanceUrl =
     : 'http://localhost:1317/cosmos/bank/v1beta1/balances/';
 const COMMAND_TIMEOUT = configMap[network].COMMAND_TIMEOUT;
 
-const agops = '/usr/src/agoric-sdk/packages/agoric-cli/bin/agops';
+const agops = 'agops';
 
 Cypress.Commands.add('addKeys', params => {
   const { keyName, mnemonic, expectedAddress } = params;
@@ -90,22 +90,32 @@ Cypress.Commands.add('placeBidByDiscount', params => {
   });
 });
 
-Cypress.Commands.add('verifyAuctionData', (propertyName, expectedValue) => {
+Cypress.Commands.add('getAuctionParam', propertyName => {
   return cy
     .exec(`${agops} inter auction status`, {
       env: { AGORIC_NET },
       failOnNonZeroExit: false,
       timeout: COMMAND_TIMEOUT,
     })
-    .then(({ stdout }) => {
-      const output = JSON.parse(stdout);
-      const propertyValue = Cypress._.get(output, propertyName);
+    .then(({ stdout, stderr }) => {
+      if (stderr && !stdout) {
+        cy.task('error', `STDERR: ${stderr}`);
+        throw Error(stderr);
+      }
+      cy.task('info', `STDOUT: ${stdout}`);
+
+      const output = JSON.parse(stdout)['book0'];
+      cy.task('info', `book0: ${JSON.stringify(output)}`);
+
+      const propertyValue = output[propertyName];
 
       if (!propertyValue) {
         throw new Error(`Error: ${propertyName} property is missing or empty`);
       }
 
-      expect(propertyValue).to.equal(expectedValue);
+      cy.task('info', `${propertyName}: ${propertyValue}`);
+
+      cy.wrap(propertyValue);
     });
 });
 
@@ -309,6 +319,6 @@ afterEach(function () {
   if (this.currentTest.state === 'failed') {
     const testName = this.currentTest.title;
     const errorMessage = this.currentTest.err.message;
-    cy.task('info', `Test "${testName}" failed with error: ${errorMessage}`);
+    cy.task('error', `Test "${testName}" failed with error: ${errorMessage}`);
   }
 });

--- a/test/e2e/support.js
+++ b/test/e2e/support.js
@@ -15,7 +15,7 @@ const balanceUrl =
     : 'http://localhost:1317/cosmos/bank/v1beta1/balances/';
 const COMMAND_TIMEOUT = configMap[network].COMMAND_TIMEOUT;
 
-const agops = 'agops';
+const agops = '/usr/src/agoric-sdk/packages/agoric-cli/bin/agops';
 
 Cypress.Commands.add('addKeys', params => {
   const { keyName, mnemonic, expectedAddress } = params;

--- a/test/e2e/test.utils.js
+++ b/test/e2e/test.utils.js
@@ -119,3 +119,8 @@ export const tokens = {
   IST: 'IST',
   BLD: 'BLD',
 };
+
+export const extractNumber = expectedValue => {
+  const match = expectedValue.match(/[\d.]+/);
+  return match ? parseFloat(match[0]) : null;
+};


### PR DESCRIPTION
Sometimes when running liquidation end-to-end tests, certain tests fail due to auction-related issues. The problem occurs because the value received from the auction doesn't exactly match the expected value, with the difference usually being a small amount, often at the last decimal place.

This PR updates the custom command for getting auction values. It ensures that we compare the correct number of decimal places for more accurate results.
