### PR TITLE
Skip tests if not enough balance

### DIFF
--- a/test/e2e/specs/liquidation-reconstitution.spec.js
+++ b/test/e2e/specs/liquidation-reconstitution.spec.js
@@ -413,16 +413,6 @@ describe('Wallet App Test Cases', () => {
       taskTimeout: DEFAULT_TASK_TIMEOUT,
     },
     () => {
-      it('should create a vault minting 400 ISTs and giving 80 ATOMs as collateral', () => {
-        cy.skipWhen(AGORIC_NET !== networks.LOCAL);
-
-        cy.createVault({
-          wantMinted: 400,
-          giveCollateral: 80,
-          userKey: 'gov1',
-        });
-      });
-
       it('should save bidder ATOM balance before placing bids', () => {
         cy.wait(QUICK_WAIT);
         cy.getTokenBalance({

--- a/test/e2e/specs/liquidation-reconstitution.spec.js
+++ b/test/e2e/specs/liquidation-reconstitution.spec.js
@@ -49,6 +49,7 @@ describe('Wallet App Test Cases', () => {
     });
 
     it('verify bidder balance is sufficient to place 3 bids', () => {
+      cy.skipWhen(AGORIC_NET === networks.LOCAL);
       cy.getTokenBalance({
         walletAddress: bidderAddress,
         token: tokens.IST,

--- a/test/e2e/specs/liquidation-reconstitution.spec.js
+++ b/test/e2e/specs/liquidation-reconstitution.spec.js
@@ -33,6 +33,34 @@ describe('Wallet App Test Cases', () => {
   let bidderAtomBalance = 0;
   let bidderIstBalance = 0;
 
+  context('Verify if both bidder and user1 have sufficient balance', () => {
+    // Note: Transaction fees are not considered in these calculations.
+
+    it('verify user1 balance is sufficient to create 3 vaults', () => {
+      cy.getTokenBalance({
+        walletAddress: user1Address,
+        token: tokens.ATOM,
+      }).then(balance => {
+        expect(
+          balance,
+          'Balance should be more than 45 ATOMs',
+        ).to.be.greaterThan(45);
+      });
+    });
+
+    it('verify bidder balance is sufficient to place 3 bids', () => {
+      cy.getTokenBalance({
+        walletAddress: bidderAddress,
+        token: tokens.IST,
+      }).then(balance => {
+        expect(
+          balance,
+          'Balance should be more than 100 ISTs',
+        ).to.be.greaterThan(100);
+      });
+    });
+  });
+
   context('Setting up accounts', () => {
     // Using exports from the synthetic-chain lib instead of hardcoding mnemonics UNTIL https://github.com/Agoric/agoric-3-proposals/issues/154
     it('should set up bidder wallet', () => {

--- a/test/e2e/specs/liquidation-reconstitution.spec.js
+++ b/test/e2e/specs/liquidation-reconstitution.spec.js
@@ -49,7 +49,6 @@ describe('Wallet App Test Cases', () => {
     });
 
     it('verify bidder balance is sufficient to place 3 bids', () => {
-      cy.skipWhen(AGORIC_NET === networks.LOCAL);
       cy.getTokenBalance({
         walletAddress: bidderAddress,
         token: tokens.IST,

--- a/test/e2e/specs/liquidation.spec.js
+++ b/test/e2e/specs/liquidation.spec.js
@@ -51,7 +51,6 @@ describe('Wallet App Test Cases', () => {
     });
 
     it('verify bidder balance is sufficient to place 3 bids', () => {
-      cy.skipWhen(AGORIC_NET === networks.LOCAL);
       cy.getTokenBalance({
         walletAddress: bidderAddress,
         token: tokens.IST,
@@ -410,11 +409,6 @@ describe('Wallet App Test Cases', () => {
   });
 
   context('Place bids and make all vaults enter liquidation', () => {
-    it('should create a vault minting 400 ISTs and giving 80 ATOMs as collateral', () => {
-      cy.skipWhen(AGORIC_NET !== networks.LOCAL);
-      cy.createVault({ wantMinted: 400, giveCollateral: 80, userKey: 'gov1' });
-    });
-
     it('should save bidder ATOM balance before placing bids', () => {
       cy.wait(QUICK_WAIT);
       cy.getTokenBalance({

--- a/test/e2e/specs/liquidation.spec.js
+++ b/test/e2e/specs/liquidation.spec.js
@@ -786,7 +786,6 @@ describe('Wallet App Test Cases', () => {
 
     it('should cancel the 1IST bid', () => {
       cy.skipWhen(AGORIC_NET !== networks.LOCAL);
-      cy.reload();
 
       cy.contains('Exit').click();
       cy.wait(QUICK_WAIT);

--- a/test/e2e/specs/liquidation.spec.js
+++ b/test/e2e/specs/liquidation.spec.js
@@ -51,6 +51,7 @@ describe('Wallet App Test Cases', () => {
     });
 
     it('verify bidder balance is sufficient to place 3 bids', () => {
+      cy.skipWhen(AGORIC_NET === networks.LOCAL);
       cy.getTokenBalance({
         walletAddress: bidderAddress,
         token: tokens.IST,

--- a/test/e2e/specs/liquidation.spec.js
+++ b/test/e2e/specs/liquidation.spec.js
@@ -35,6 +35,34 @@ describe('Wallet App Test Cases', () => {
   let user1AtomBalance = 0;
   let bidderIstBalance = 0;
 
+  context('Verify if both bidder and user1 have sufficient balance', () => {
+    // Note: Transaction fees are not considered in these calculations.
+
+    it('verify user1 balance is sufficient to create 3 vaults', () => {
+      cy.getTokenBalance({
+        walletAddress: user1Address,
+        token: tokens.ATOM,
+      }).then(balance => {
+        expect(
+          balance,
+          'Balance should be more than 45 ATOMs',
+        ).to.be.greaterThan(45);
+      });
+    });
+
+    it('verify bidder balance is sufficient to place 3 bids', () => {
+      cy.getTokenBalance({
+        walletAddress: bidderAddress,
+        token: tokens.IST,
+      }).then(balance => {
+        expect(
+          balance,
+          'Balance should be more than 320 ISTs',
+        ).to.be.greaterThan(320);
+      });
+    });
+  });
+
   context('Setting up accounts', () => {
     // Using exports from the synthetic-chain lib instead of hardcoding mnemonics UNTIL https://github.com/Agoric/agoric-3-proposals/issues/154
     it('should set up bidder wallet', () => {
@@ -47,6 +75,7 @@ describe('Wallet App Test Cases', () => {
         expect(taskCompleted).to.be.true;
       });
     });
+
     it('should set up user1 wallet', () => {
       cy.task('info', `AGORIC_NET: ${AGORIC_NET}`);
       cy.setupWallet({

--- a/test/e2e/support.js
+++ b/test/e2e/support.js
@@ -315,10 +315,30 @@ Cypress.Commands.add('getTokenBalance', ({ walletAddress, token }) => {
   });
 });
 
+let shouldSkip = false;
+
+beforeEach(function () {
+  if (shouldSkip) {
+    throw new Error(
+      'Test skipped: user1 or bidder do not have sufficient balance.',
+    );
+  }
+});
+
 afterEach(function () {
   if (this.currentTest.state === 'failed') {
     const testName = this.currentTest.title;
     const errorMessage = this.currentTest.err.message;
+
+    if (
+      [
+        'verify user1 balance is sufficient to create 3 vaults',
+        'verify bidder balance is sufficient to place 3 bids',
+      ].includes(testName)
+    ) {
+      shouldSkip = true;
+    }
+
     cy.task('error', `Test "${testName}" failed with error: ${errorMessage}`);
   }
 });

--- a/test/e2e/support.js
+++ b/test/e2e/support.js
@@ -23,7 +23,12 @@ Cypress.Commands.add('addKeys', params => {
 
   cy.exec(command, {
     failOnNonZeroExit: false,
-  }).then(({ stdout }) => {
+  }).then(({ stdout, stderr }) => {
+    if (stderr && !stdout) {
+      cy.task('error', `STDERR: ${stderr}`);
+      throw Error(stderr);
+    }
+    cy.task('info', `STDOUT: ${stdout}`);
     expect(stdout).to.contain(expectedAddress);
   });
 });
@@ -35,7 +40,12 @@ Cypress.Commands.add('setOraclePrice', price => {
       env: { AGORIC_NET },
       timeout: COMMAND_TIMEOUT,
     },
-  ).then(({ stdout }) => {
+  ).then(({ stdout, stderr }) => {
+    if (stderr && !stdout) {
+      cy.task('error', `STDERR: ${stderr}`);
+      throw Error(stderr);
+    }
+    cy.task('info', `STDOUT: ${stdout}`);
     expect(stdout).to.not.contain('Error');
     expect(stdout).to.not.contain('error');
   });
@@ -57,7 +67,12 @@ Cypress.Commands.add('createVault', params => {
     cy.exec(broadcastCommand, {
       env: { AGORIC_NET },
       timeout: COMMAND_TIMEOUT,
-    }).then(({ stdout }) => {
+    }).then(({ stdout, stderr }) => {
+      if (stderr && !stdout) {
+        cy.task('error', `STDERR: ${stderr}`);
+        throw Error(stderr);
+      }
+      cy.task('info', `STDOUT: ${stdout}`);
       expect(stdout).not.to.contain('Error');
     });
   });
@@ -71,7 +86,12 @@ Cypress.Commands.add('placeBidByPrice', params => {
     env: { AGORIC_NET },
     timeout: COMMAND_TIMEOUT,
     failOnNonZeroExit: false,
-  }).then(({ stdout }) => {
+  }).then(({ stdout, stderr }) => {
+    if (stderr && !stdout) {
+      cy.task('error', `STDERR: ${stderr}`);
+      throw Error(stderr);
+    }
+    cy.task('info', `STDOUT: ${stdout}`);
     expect(stdout).to.contain('Your bid has been accepted');
   });
 });
@@ -85,7 +105,12 @@ Cypress.Commands.add('placeBidByDiscount', params => {
     env: { AGORIC_NET },
     timeout: COMMAND_TIMEOUT,
     failOnNonZeroExit: false,
-  }).then(({ stdout }) => {
+  }).then(({ stdout, stderr }) => {
+    if (stderr && !stdout) {
+      cy.task('error', `STDERR: ${stderr}`);
+      throw Error(stderr);
+    }
+    cy.task('info', `STDOUT: ${stdout}`);
     expect(stdout).to.contain('Your bid has been accepted');
   });
 });


### PR DESCRIPTION
The PR:
- Verifies `user1` and `bidder` balance before executing all tests. This is done to exit early in case the balances are not enough to carry out test operations. Previously, we had executed a major section of tests before realizing that we didn't possess enough balance to create a vault or make a bid. 
- Removes an A3P test for creating a vault which is no longer required. Previously, this test case was added to ensure `gov1` has enough `IST` to make bids. But this is no longer required because `gov1` already have enough balance to carry out bidding stuff. 
- Adding logs wherever we execute commands with `agops` and `agd`. 