### PR TITLE
chore: compare values upto 2 decimal places

### DIFF
--- a/test/e2e/specs/liquidation-reconstitution.spec.js
+++ b/test/e2e/specs/liquidation-reconstitution.spec.js
@@ -673,7 +673,7 @@ describe('Wallet App Test Cases', () => {
         );
         cy.task('info', `Actual increase: ${balanceIncrease}`);
 
-        expect(balanceIncrease).to.eq(expectedValue);
+        expect(balanceIncrease).to.eq(Number(expectedValue.toFixed(2)));
       });
     });
   });


### PR DESCRIPTION
This PR ensures that the expected value for shortfall balance comparisons is rounded to two decimal places, matching the format of the actual test output.

Currently, the comparison fails because the actual value `5.53` does not match the expected value `5.525`.
