### PR TITLE
fix e2e tests issues when running with emerynet

### DIFF
--- a/test/e2e/specs/liquidation-reconstitution.spec.js
+++ b/test/e2e/specs/liquidation-reconstitution.spec.js
@@ -505,99 +505,108 @@ describe('Liquidation Reconstitution Testing', () => {
     },
   );
 
-  context('Verify auction values while vaults are LIQUIDATING', () => {
-    it('should verify the value of startPrice', () => {
-      cy.wait(QUICK_WAIT);
+  context(
+    'Verify auction values while vaults are LIQUIDATING',
+    {
+      retries: {
+        runMode: 2,
+        openMode: 2,
+      },
+    },
+    () => {
+      it('should verify the value of startPrice', () => {
+        cy.wait(QUICK_WAIT);
 
-      if (AGORIC_NET === networks.LOCAL) {
-        const expectedValue = 9.99;
-        cy.task('info', `Expected Value: ${expectedValue}`);
-        cy.fetchVStorageData({
-          url: auctionURL,
-          field: 'startPrice',
-        }).then(data => {
-          cy.calculateRatios(data, { hasDenom: true, useValue: false }).then(
-            result => {
-              const valueFound = result.includes(expectedValue);
-              expect(valueFound).to.be.true;
-            },
-          );
-        });
-      } else {
-        const propertyName = 'startPrice';
-        const expectedValue = '9.99 IST/ATOM';
-        cy.task('info', `Expected Value: ${expectedValue}`);
-        cy.getAuctionParam(propertyName).then(value => {
-          const actualValue = extractNumber(value);
-          const expectedValueRounded = extractNumber(expectedValue);
+        if (AGORIC_NET === networks.LOCAL) {
+          const expectedValue = 9.99;
+          cy.task('info', `Expected Value: ${expectedValue}`);
+          cy.fetchVStorageData({
+            url: auctionURL,
+            field: 'startPrice',
+          }).then(data => {
+            cy.calculateRatios(data, { hasDenom: true, useValue: false }).then(
+              result => {
+                const valueFound = result.includes(expectedValue);
+                expect(valueFound).to.be.true;
+              },
+            );
+          });
+        } else {
+          const propertyName = 'startPrice';
+          const expectedValue = '9.99 IST/ATOM';
+          cy.task('info', `Expected Value: ${expectedValue}`);
+          cy.getAuctionParam(propertyName).then(value => {
+            const actualValue = extractNumber(value);
+            const expectedValueRounded = extractNumber(expectedValue);
 
-          expect(actualValue).to.eq(expectedValueRounded);
-        });
-      }
-    });
+            expect(actualValue).to.eq(expectedValueRounded);
+          });
+        }
+      });
 
-    it('should verify the value of startProceedsGoal', () => {
-      if (AGORIC_NET === networks.LOCAL) {
-        const expectedValue = 309.54;
-        cy.task('info', `Expected Value: ${expectedValue}`);
-        cy.fetchVStorageData({
-          url: auctionURL,
-          field: 'startProceedsGoal',
-        }).then(data => {
-          cy.calculateRatios(data, { hasDenom: false, useValue: true }).then(
-            result => {
-              const valueFound = result.includes(expectedValue);
-              expect(valueFound).to.be.true;
-            },
-          );
-        });
-      } else {
-        const propertyName = 'startProceedsGoal';
-        const expectedValue = '309.54 IST';
-        cy.task('info', `Expected Value: ${expectedValue}`);
-        cy.getAuctionParam(propertyName).then(value => {
-          cy.task(
-            'info',
-            'Comparing actual and expected values rounded to one decimal place.',
-          );
+      it('should verify the value of startProceedsGoal', () => {
+        if (AGORIC_NET === networks.LOCAL) {
+          const expectedValue = 309.54;
+          cy.task('info', `Expected Value: ${expectedValue}`);
+          cy.fetchVStorageData({
+            url: auctionURL,
+            field: 'startProceedsGoal',
+          }).then(data => {
+            cy.calculateRatios(data, { hasDenom: false, useValue: true }).then(
+              result => {
+                const valueFound = result.includes(expectedValue);
+                expect(valueFound).to.be.true;
+              },
+            );
+          });
+        } else {
+          const propertyName = 'startProceedsGoal';
+          const expectedValue = '309.54 IST';
+          cy.task('info', `Expected Value: ${expectedValue}`);
+          cy.getAuctionParam(propertyName).then(value => {
+            cy.task(
+              'info',
+              'Comparing actual and expected values rounded to one decimal place.',
+            );
 
-          const actualValue = Math.round(extractNumber(value) * 10) / 10;
-          const expectedValueRounded =
-            Math.round(extractNumber(expectedValue) * 10) / 10;
+            const actualValue = Math.round(extractNumber(value) * 10) / 10;
+            const expectedValueRounded =
+              Math.round(extractNumber(expectedValue) * 10) / 10;
 
-          expect(actualValue).to.eq(expectedValueRounded);
-        });
-      }
-    });
+            expect(actualValue).to.eq(expectedValueRounded);
+          });
+        }
+      });
 
-    it('should verify the value of startCollateral', () => {
-      if (AGORIC_NET === networks.LOCAL) {
-        const expectedValue = 45;
-        cy.task('info', `Expected Value: ${expectedValue}`);
-        cy.fetchVStorageData({
-          url: auctionURL,
-          field: 'startCollateral',
-        }).then(data => {
-          cy.calculateRatios(data, { hasDenom: false, useValue: true }).then(
-            result => {
-              const valueFound = result.includes(expectedValue);
-              expect(valueFound).to.be.true;
-            },
-          );
-        });
-      } else {
-        const propertyName = 'startCollateral';
-        const expectedValue = '45 ATOM';
-        cy.task('info', `Expected Value: ${expectedValue}`);
-        cy.getAuctionParam(propertyName).then(value => {
-          const actualValue = extractNumber(value);
-          const expectedValueRounded = extractNumber(expectedValue);
+      it('should verify the value of startCollateral', () => {
+        if (AGORIC_NET === networks.LOCAL) {
+          const expectedValue = 45;
+          cy.task('info', `Expected Value: ${expectedValue}`);
+          cy.fetchVStorageData({
+            url: auctionURL,
+            field: 'startCollateral',
+          }).then(data => {
+            cy.calculateRatios(data, { hasDenom: false, useValue: true }).then(
+              result => {
+                const valueFound = result.includes(expectedValue);
+                expect(valueFound).to.be.true;
+              },
+            );
+          });
+        } else {
+          const propertyName = 'startCollateral';
+          const expectedValue = '45 ATOM';
+          cy.task('info', `Expected Value: ${expectedValue}`);
+          cy.getAuctionParam(propertyName).then(value => {
+            const actualValue = extractNumber(value);
+            const expectedValueRounded = extractNumber(expectedValue);
 
-          expect(actualValue).to.eq(expectedValueRounded);
-        });
-      }
-    });
-  });
+            expect(actualValue).to.eq(expectedValueRounded);
+          });
+        }
+      });
+    },
+  );
 
   context(
     'Wait for two vaults to be RECONSTITUTED and one to be LIQUIDATED',

--- a/test/e2e/specs/liquidation-reconstitution.spec.js
+++ b/test/e2e/specs/liquidation-reconstitution.spec.js
@@ -442,7 +442,9 @@ describe('Wallet App Test Cases', () => {
           field: 'shortfallBalance',
           latest: true,
         }).then(output => {
-          shortfallBalance = Number(Number(output.value.slice(1)).toFixed(2));
+          shortfallBalance = Number(
+            (Number(output.value.slice(1)) / 1_000_000).toFixed(2),
+          );
           cy.task('info', `Current Shortfall balance: ${shortfallBalance}`);
         });
       });

--- a/test/e2e/specs/liquidation-reconstitution.spec.js
+++ b/test/e2e/specs/liquidation-reconstitution.spec.js
@@ -3,7 +3,8 @@ import {
   MINUTE_MS,
   networks,
   configMap,
-  QUICK_WAIT,
+  QUICK_WAIT_LOCAL,
+  QUICK_WAIT_TESTNET,
   webWalletURL,
   webWalletSelectors,
   tokens,
@@ -15,6 +16,8 @@ describe('Wallet App Test Cases', () => {
   const AGORIC_NET = Cypress.env('AGORIC_NET');
   const network = AGORIC_NET !== 'local' ? 'testnet' : 'local';
   const currentConfig = configMap[network];
+  const QUICK_WAIT =
+    AGORIC_NET === 'local' ? QUICK_WAIT_LOCAL : QUICK_WAIT_TESTNET;
   const DEFAULT_TIMEOUT = currentConfig.DEFAULT_TIMEOUT;
   const DEFAULT_TASK_TIMEOUT = currentConfig.DEFAULT_TASK_TIMEOUT;
   const LIQUIDATING_TIMEOUT = currentConfig.LIQUIDATING_TIMEOUT;

--- a/test/e2e/specs/liquidation-reconstitution.spec.js
+++ b/test/e2e/specs/liquidation-reconstitution.spec.js
@@ -11,7 +11,7 @@ import {
   extractNumber,
 } from '../test.utils';
 
-describe('Wallet App Test Cases', () => {
+describe('Liquidation Reconstitution Testing', () => {
   let startTime;
   const AGORIC_NET = Cypress.env('AGORIC_NET');
   const network = AGORIC_NET !== 'local' ? 'testnet' : 'local';
@@ -474,12 +474,16 @@ describe('Wallet App Test Cases', () => {
         cy.getTokenBalance({
           walletAddress: bidderAddress,
           token: tokens.IST,
-        }).then(newBalance => {
-          cy.task('info', `Initial Balance: ${bidderIstBalance}`);
-          cy.task('info', `New Balance: ${newBalance}`);
-          expect(newBalance).to.be.lessThan(bidderIstBalance);
-          bidderIstBalance = newBalance;
-        });
+        })
+          .then(newBalance => {
+            cy.task('info', `Initial Balance: ${bidderIstBalance}`);
+            cy.task('info', `New Balance: ${newBalance}`);
+            cy.wrap(newBalance);
+          })
+          .then(newBalance => {
+            expect(newBalance).to.be.lessThan(bidderIstBalance);
+            bidderIstBalance = newBalance;
+          });
       });
 
       it('should set ATOM price to 9.99', () => {
@@ -666,20 +670,26 @@ describe('Wallet App Test Cases', () => {
         url: reserveURL,
         field: 'shortfallBalance',
         latest: true,
-      }).then(newBalanceObj => {
-        let newBalance = Number(
-          (Number(newBalanceObj.value.slice(1)) / 1_000_000).toFixed(2),
-        );
-        cy.task('info', `Initial shortfallBalance: ${shortfallBalance}`);
-        cy.task('info', `New shortfallBalance: ${JSON.stringify(newBalance)}`);
+      })
+        .then(newBalanceObj => {
+          let newBalance = Number(
+            (Number(newBalanceObj.value.slice(1)) / 1_000_000).toFixed(2),
+          );
+          cy.task('info', `Initial shortfallBalance: ${shortfallBalance}`);
+          cy.task(
+            'info',
+            `New shortfallBalance: ${JSON.stringify(newBalance)}`,
+          );
 
-        const balanceIncrease = Number(
-          (newBalance - shortfallBalance).toFixed(2),
-        );
-        cy.task('info', `Actual increase: ${balanceIncrease}`);
-
-        expect(balanceIncrease).to.eq(Number(expectedValue.toFixed(2)));
-      });
+          const balanceIncrease = Number(
+            (newBalance - shortfallBalance).toFixed(2),
+          );
+          cy.task('info', `Actual increase: ${balanceIncrease}`);
+          cy.wrap(balanceIncrease);
+        })
+        .then(balanceIncrease => {
+          expect(balanceIncrease).to.eq(Number(expectedValue.toFixed(2)));
+        });
     });
   });
 
@@ -694,18 +704,21 @@ describe('Wallet App Test Cases', () => {
       cy.getTokenBalance({
         walletAddress: bidderAddress,
         token: tokens.ATOM,
-      }).then(newBalance => {
-        cy.task('info', `Initial Balance: ${bidderAtomBalance}`);
-        cy.task('info', `New Balance: ${newBalance}`);
+      })
+        .then(newBalance => {
+          cy.task('info', `Initial Balance: ${bidderAtomBalance}`);
+          cy.task('info', `New Balance: ${newBalance}`);
 
-        const balanceIncrease = Number(
-          (newBalance - bidderAtomBalance).toFixed(3),
-        );
-        cy.task('info', `Actual increase: ${balanceIncrease}`);
-        bidderAtomBalance = Number(newBalance.toFixed(2));
-
-        expect(balanceIncrease).to.eq(expectedValue);
-      });
+          const balanceIncrease = Number(
+            (newBalance - bidderAtomBalance).toFixed(3),
+          );
+          cy.task('info', `Actual increase: ${balanceIncrease}`);
+          bidderAtomBalance = Number(newBalance.toFixed(2));
+          cy.wrap(balanceIncrease);
+        })
+        .then(balanceIncrease => {
+          expect(balanceIncrease).to.eq(expectedValue);
+        });
     });
 
     it('should switch to the bidder wallet successfully', () => {

--- a/test/e2e/specs/liquidation.spec.js
+++ b/test/e2e/specs/liquidation.spec.js
@@ -851,7 +851,6 @@ describe('Wallet App Test Cases', () => {
     });
 
     it('should save bidder ATOM balance', () => {
-      cy.skipWhen(AGORIC_NET !== networks.LOCAL);
       cy.wait(QUICK_WAIT);
       cy.getTokenBalance({
         walletAddress: bidderAddress,

--- a/test/e2e/specs/liquidation.spec.js
+++ b/test/e2e/specs/liquidation.spec.js
@@ -12,7 +12,7 @@ import {
   extractNumber,
 } from '../test.utils';
 
-describe('Wallet App Test Cases', () => {
+describe('Liquidation Testing', () => {
   let startTime;
   const AGORIC_NET = Cypress.env('AGORIC_NET');
   const network = AGORIC_NET !== 'local' ? 'testnet' : 'local';
@@ -483,12 +483,17 @@ describe('Wallet App Test Cases', () => {
       cy.getTokenBalance({
         walletAddress: bidderAddress,
         token: tokens.IST,
-      }).then(newBalance => {
-        cy.task('info', `Initial Balance: ${bidderIstBalance}`);
-        cy.task('info', `New Balance: ${newBalance}`);
-        expect(newBalance).to.be.lessThan(bidderIstBalance);
-        bidderIstBalance = newBalance;
-      });
+      })
+        .then(newBalance => {
+          cy.task('info', `Initial Balance: ${bidderIstBalance}`);
+          cy.task('info', `New Balance: ${newBalance}`);
+
+          cy.wrap(newBalance);
+        })
+        .then(newBalance => {
+          expect(newBalance).to.be.lessThan(bidderIstBalance);
+          bidderIstBalance = newBalance;
+        });
     });
 
     it('should set ATOM price to 9.99', () => {
@@ -718,17 +723,19 @@ describe('Wallet App Test Cases', () => {
       cy.getTokenBalance({
         walletAddress: user1Address,
         token: tokens.ATOM,
-      }).then(newBalance => {
-        cy.task('info', `Initial Balance: ${user1AtomBalance}`);
-        cy.task('info', `New Balance: ${newBalance}`);
-
-        const balanceIncrease = Number(
-          (newBalance - user1AtomBalance).toFixed(2),
-        );
-        cy.task('info', `Actual increase: ${balanceIncrease}`);
-
-        expect(balanceIncrease).to.eq(expectedValue);
-      });
+      })
+        .then(newBalance => {
+          cy.task('info', `Initial Balance: ${user1AtomBalance}`);
+          cy.task('info', `New Balance: ${newBalance}`);
+          const balanceIncrease = Number(
+            (newBalance - user1AtomBalance).toFixed(2),
+          );
+          cy.task('info', `Actual increase: ${balanceIncrease}`);
+          cy.wrap(balanceIncrease);
+        })
+        .then(balanceIncrease => {
+          expect(balanceIncrease).to.eq(expectedValue);
+        });
     });
   });
 
@@ -741,21 +748,28 @@ describe('Wallet App Test Cases', () => {
         url: reserveURL,
         field: 'shortfallBalance',
         latest: true,
-      }).then(newBalanceObj => {
-        let newBalance = Number(
-          (Number(newBalanceObj.value.slice(1)) / 1_000_000).toFixed(2),
-        );
+      })
+        .then(newBalanceObj => {
+          let newBalance = Number(
+            (Number(newBalanceObj.value.slice(1)) / 1_000_000).toFixed(2),
+          );
 
-        cy.task('info', `Initial shortfallBalance: ${shortfallBalance}`);
-        cy.task('info', `New shortfallBalance: ${JSON.stringify(newBalance)}`);
+          cy.task('info', `Initial shortfallBalance: ${shortfallBalance}`);
+          cy.task(
+            'info',
+            `New shortfallBalance: ${JSON.stringify(newBalance)}`,
+          );
 
-        const balanceIncrease = Number(
-          (newBalance - shortfallBalance).toFixed(2),
-        );
-        cy.task('info', `Actual increase: ${balanceIncrease}`);
+          const balanceIncrease = Number(
+            (newBalance - shortfallBalance).toFixed(2),
+          );
+          cy.task('info', `Actual increase: ${balanceIncrease}`);
 
-        expect(balanceIncrease).to.eq(expectedValue);
-      });
+          cy.wrap(balanceIncrease);
+        })
+        .then(balanceIncrease => {
+          expect(balanceIncrease).to.eq(expectedValue);
+        });
     });
   });
 
@@ -770,18 +784,22 @@ describe('Wallet App Test Cases', () => {
       cy.getTokenBalance({
         walletAddress: bidderAddress,
         token: tokens.ATOM,
-      }).then(newBalance => {
-        cy.task('info', `Initial Balance: ${bidderAtomBalance}`);
-        cy.task('info', `New Balance: ${newBalance}`);
+      })
+        .then(newBalance => {
+          cy.task('info', `Initial Balance: ${bidderAtomBalance}`);
+          cy.task('info', `New Balance: ${newBalance}`);
 
-        const balanceIncrease = Number(
-          (newBalance - bidderAtomBalance).toFixed(2),
-        );
-        cy.task('info', `Actual increase: ${balanceIncrease}`);
-        bidderAtomBalance = Number(newBalance.toFixed(2));
+          const balanceIncrease = Number(
+            (newBalance - bidderAtomBalance).toFixed(2),
+          );
+          cy.task('info', `Actual increase: ${balanceIncrease}`);
+          bidderAtomBalance = Number(newBalance.toFixed(2));
 
-        expect(balanceIncrease).to.eq(expectedValue);
-      });
+          cy.wrap(balanceIncrease);
+        })
+        .then(balanceIncrease => {
+          expect(balanceIncrease).to.eq(expectedValue);
+        });
     });
 
     it('should switch to the bidder wallet successfully', () => {
@@ -847,12 +865,17 @@ describe('Wallet App Test Cases', () => {
       cy.getTokenBalance({
         walletAddress: bidderAddress,
         token: tokens.IST,
-      }).then(newBalance => {
-        cy.task('info', `Initial Balance: ${bidderIstBalance}`);
-        cy.task('info', `New Balance: ${newBalance}`);
-        expect(newBalance).to.be.greaterThan(bidderIstBalance);
-        bidderIstBalance = newBalance;
-      });
+      })
+        .then(newBalance => {
+          cy.task('info', `Initial Balance: ${bidderIstBalance}`);
+          cy.task('info', `New Balance: ${newBalance}`);
+
+          cy.wrap(newBalance);
+        })
+        .then(newBalance => {
+          expect(newBalance).to.be.greaterThan(bidderIstBalance);
+          bidderIstBalance = newBalance;
+        });
     });
 
     it('should save bidder ATOM balance', () => {
@@ -884,12 +907,17 @@ describe('Wallet App Test Cases', () => {
       cy.getTokenBalance({
         walletAddress: bidderAddress,
         token: tokens.IST,
-      }).then(newBalance => {
-        cy.task('info', `Initial Balance: ${bidderIstBalance}`);
-        cy.task('info', `New Balance: ${newBalance}`);
-        expect(newBalance).to.be.greaterThan(bidderIstBalance);
-        bidderIstBalance = newBalance;
-      });
+      })
+        .then(newBalance => {
+          cy.task('info', `Initial Balance: ${bidderIstBalance}`);
+          cy.task('info', `New Balance: ${newBalance}`);
+
+          cy.wrap(newBalance);
+        })
+        .then(newBalance => {
+          expect(newBalance).to.be.greaterThan(bidderIstBalance);
+          bidderIstBalance = newBalance;
+        });
     });
 
     it("should see increase in the bidder's ATOM balance because of partially filled bid", () => {
@@ -904,17 +932,21 @@ describe('Wallet App Test Cases', () => {
       cy.getTokenBalance({
         walletAddress: bidderAddress,
         token: tokens.ATOM,
-      }).then(newBalance => {
-        cy.task('info', `Initial Balance: ${bidderAtomBalance}`);
-        cy.task('info', `New Balance: ${newBalance}`);
+      })
+        .then(newBalance => {
+          cy.task('info', `Initial Balance: ${bidderAtomBalance}`);
+          cy.task('info', `New Balance: ${newBalance}`);
 
-        const balanceIncrease = Number(
-          (newBalance - bidderAtomBalance).toFixed(2),
-        );
-        cy.task('info', `Actual increase: ${balanceIncrease}`);
+          const balanceIncrease = Number(
+            (newBalance - bidderAtomBalance).toFixed(2),
+          );
+          cy.task('info', `Actual increase: ${balanceIncrease}`);
 
-        expect(balanceIncrease).to.eq(expectedValue);
-      });
+          cy.wrap(balanceIncrease);
+        })
+        .then(balanceIncrease => {
+          expect(balanceIncrease).to.eq(expectedValue);
+        });
     });
   });
 

--- a/test/e2e/specs/liquidation.spec.js
+++ b/test/e2e/specs/liquidation.spec.js
@@ -5,7 +5,8 @@ import {
   configMap,
   webWalletURL,
   webWalletSelectors,
-  QUICK_WAIT,
+  QUICK_WAIT_LOCAL,
+  QUICK_WAIT_TESTNET,
   THIRTY_SECONDS,
   tokens,
   extractNumber,
@@ -16,6 +17,8 @@ describe('Wallet App Test Cases', () => {
   const AGORIC_NET = Cypress.env('AGORIC_NET');
   const network = AGORIC_NET !== 'local' ? 'testnet' : 'local';
   const currentConfig = configMap[network];
+  const QUICK_WAIT =
+    AGORIC_NET === 'local' ? QUICK_WAIT_LOCAL : QUICK_WAIT_TESTNET;
   const DEFAULT_TIMEOUT = currentConfig.DEFAULT_TIMEOUT;
   const DEFAULT_TASK_TIMEOUT = currentConfig.DEFAULT_TASK_TIMEOUT;
   const LIQUIDATING_TIMEOUT = currentConfig.LIQUIDATING_TIMEOUT;

--- a/test/e2e/specs/liquidation.spec.js
+++ b/test/e2e/specs/liquidation.spec.js
@@ -514,99 +514,108 @@ describe('Liquidation Testing', () => {
     });
   });
 
-  context('Verify auction values while vaults are LIQUIDATING', () => {
-    it('should verify the value of startPrice', () => {
-      cy.wait(THIRTY_SECONDS);
+  context(
+    'Verify auction values while vaults are LIQUIDATING',
+    {
+      retries: {
+        runMode: 2,
+        openMode: 2,
+      },
+    },
+    () => {
+      it('should verify the value of startPrice', () => {
+        cy.wait(THIRTY_SECONDS);
 
-      if (AGORIC_NET === networks.LOCAL) {
-        const expectedValue = 9.99;
-        cy.task('info', `Expected Value: ${expectedValue}`);
-        cy.fetchVStorageData({
-          url: auctionURL,
-          field: 'startPrice',
-        }).then(data => {
-          cy.calculateRatios(data, { hasDenom: true, useValue: false }).then(
-            result => {
-              const valueFound = result.includes(expectedValue);
-              expect(valueFound).to.be.true;
-            },
-          );
-        });
-      } else {
-        const propertyName = 'startPrice';
-        const expectedValue = '9.99 IST/ATOM';
-        cy.task('info', `Expected Value: ${expectedValue}`);
-        cy.getAuctionParam(propertyName).then(value => {
-          const actualValue = extractNumber(value);
-          const expectedValueRounded = extractNumber(expectedValue);
+        if (AGORIC_NET === networks.LOCAL) {
+          const expectedValue = 9.99;
+          cy.task('info', `Expected Value: ${expectedValue}`);
+          cy.fetchVStorageData({
+            url: auctionURL,
+            field: 'startPrice',
+          }).then(data => {
+            cy.calculateRatios(data, { hasDenom: true, useValue: false }).then(
+              result => {
+                const valueFound = result.includes(expectedValue);
+                expect(valueFound).to.be.true;
+              },
+            );
+          });
+        } else {
+          const propertyName = 'startPrice';
+          const expectedValue = '9.99 IST/ATOM';
+          cy.task('info', `Expected Value: ${expectedValue}`);
+          cy.getAuctionParam(propertyName).then(value => {
+            const actualValue = extractNumber(value);
+            const expectedValueRounded = extractNumber(expectedValue);
 
-          expect(actualValue).to.eq(expectedValueRounded);
-        });
-      }
-    });
+            expect(actualValue).to.eq(expectedValueRounded);
+          });
+        }
+      });
 
-    it('should verify the value of startProceedsGoal', () => {
-      if (AGORIC_NET === networks.LOCAL) {
-        const expectedValue = 309.54;
-        cy.task('info', `Expected Value: ${expectedValue}`);
-        cy.fetchVStorageData({
-          url: auctionURL,
-          field: 'startProceedsGoal',
-        }).then(data => {
-          cy.calculateRatios(data, { hasDenom: false, useValue: true }).then(
-            result => {
-              const valueFound = result.includes(expectedValue);
-              expect(valueFound).to.be.true;
-            },
-          );
-        });
-      } else {
-        const propertyName = 'startProceedsGoal';
-        const expectedValue = '309.54 IST';
-        cy.task('info', `Expected Value: ${expectedValue}`);
-        cy.getAuctionParam(propertyName).then(value => {
-          cy.task(
-            'info',
-            'Comparing actual and expected values rounded to one decimal place.',
-          );
+      it('should verify the value of startProceedsGoal', () => {
+        if (AGORIC_NET === networks.LOCAL) {
+          const expectedValue = 309.54;
+          cy.task('info', `Expected Value: ${expectedValue}`);
+          cy.fetchVStorageData({
+            url: auctionURL,
+            field: 'startProceedsGoal',
+          }).then(data => {
+            cy.calculateRatios(data, { hasDenom: false, useValue: true }).then(
+              result => {
+                const valueFound = result.includes(expectedValue);
+                expect(valueFound).to.be.true;
+              },
+            );
+          });
+        } else {
+          const propertyName = 'startProceedsGoal';
+          const expectedValue = '309.54 IST';
+          cy.task('info', `Expected Value: ${expectedValue}`);
+          cy.getAuctionParam(propertyName).then(value => {
+            cy.task(
+              'info',
+              'Comparing actual and expected values rounded to one decimal place.',
+            );
 
-          const actualValue = Math.round(extractNumber(value) * 10) / 10;
-          const expectedValueRounded =
-            Math.round(extractNumber(expectedValue) * 10) / 10;
+            const actualValue = Math.round(extractNumber(value) * 10) / 10;
+            const expectedValueRounded =
+              Math.round(extractNumber(expectedValue) * 10) / 10;
 
-          expect(actualValue).to.eq(expectedValueRounded);
-        });
-      }
-    });
+            expect(actualValue).to.eq(expectedValueRounded);
+          });
+        }
+      });
 
-    it('should verify the value of startCollateral', () => {
-      if (AGORIC_NET === networks.LOCAL) {
-        const expectedValue = 45;
-        cy.task('info', `Expected Value: ${expectedValue}`);
-        cy.fetchVStorageData({
-          url: auctionURL,
-          field: 'startCollateral',
-        }).then(data => {
-          cy.calculateRatios(data, { hasDenom: false, useValue: true }).then(
-            result => {
-              const valueFound = result.includes(expectedValue);
-              expect(valueFound).to.be.true;
-            },
-          );
-        });
-      } else {
-        const propertyName = 'startCollateral';
-        const expectedValue = '45 ATOM';
-        cy.task('info', `Expected Value: ${expectedValue}`);
-        cy.getAuctionParam(propertyName).then(value => {
-          const actualValue = extractNumber(value);
-          const expectedValueRounded = extractNumber(expectedValue);
+      it('should verify the value of startCollateral', () => {
+        if (AGORIC_NET === networks.LOCAL) {
+          const expectedValue = 45;
+          cy.task('info', `Expected Value: ${expectedValue}`);
+          cy.fetchVStorageData({
+            url: auctionURL,
+            field: 'startCollateral',
+          }).then(data => {
+            cy.calculateRatios(data, { hasDenom: false, useValue: true }).then(
+              result => {
+                const valueFound = result.includes(expectedValue);
+                expect(valueFound).to.be.true;
+              },
+            );
+          });
+        } else {
+          const propertyName = 'startCollateral';
+          const expectedValue = '45 ATOM';
+          cy.task('info', `Expected Value: ${expectedValue}`);
+          cy.getAuctionParam(propertyName).then(value => {
+            const actualValue = extractNumber(value);
+            const expectedValueRounded = extractNumber(expectedValue);
 
-          expect(actualValue).to.eq(expectedValueRounded);
-        });
-      }
-    });
-  });
+            expect(actualValue).to.eq(expectedValueRounded);
+          });
+        }
+      });
+    },
+  );
 
   context('Wait for Vaults to be LIQUIDATED', () => {
     it(
@@ -625,41 +634,50 @@ describe('Liquidation Testing', () => {
       },
     );
 
-    it('should verify the value of collateralAvailable', () => {
-      cy.wait(QUICK_WAIT);
+    it(
+      'should verify the value of collateralAvailable',
+      {
+        retries: {
+          runMode: 2,
+          openMode: 2,
+        },
+      },
+      () => {
+        cy.wait(QUICK_WAIT);
 
-      if (AGORIC_NET === networks.LOCAL) {
-        const expectedValue = 9.659301;
-        cy.task('info', `Expected Value: ${expectedValue}`);
-        cy.fetchVStorageData({
-          url: auctionURL,
-          field: 'collateralAvailable',
-        }).then(data => {
-          cy.calculateRatios(data, { hasDenom: false, useValue: true }).then(
-            result => {
-              const valueFound = result.includes(expectedValue);
-              expect(valueFound).to.be.true;
-            },
-          );
-        });
-      } else {
-        const propertyName = 'collateralAvailable';
-        const expectedValue = '9.659301 ATOM';
-        cy.task('info', `Expected Value: ${expectedValue}`);
-        cy.getAuctionParam(propertyName).then(value => {
-          cy.task(
-            'info',
-            'Comparing actual and expected values rounded to one decimal place.',
-          );
+        if (AGORIC_NET === networks.LOCAL) {
+          const expectedValue = 9.659301;
+          cy.task('info', `Expected Value: ${expectedValue}`);
+          cy.fetchVStorageData({
+            url: auctionURL,
+            field: 'collateralAvailable',
+          }).then(data => {
+            cy.calculateRatios(data, { hasDenom: false, useValue: true }).then(
+              result => {
+                const valueFound = result.includes(expectedValue);
+                expect(valueFound).to.be.true;
+              },
+            );
+          });
+        } else {
+          const propertyName = 'collateralAvailable';
+          const expectedValue = '9.659301 ATOM';
+          cy.task('info', `Expected Value: ${expectedValue}`);
+          cy.getAuctionParam(propertyName).then(value => {
+            cy.task(
+              'info',
+              'Comparing actual and expected values rounded to one decimal place.',
+            );
 
-          const actualValue = Math.round(extractNumber(value) * 10) / 10;
-          const expectedValueRounded =
-            Math.round(extractNumber(expectedValue) * 10) / 10;
+            const actualValue = Math.round(extractNumber(value) * 10) / 10;
+            const expectedValueRounded =
+              Math.round(extractNumber(expectedValue) * 10) / 10;
 
-          expect(actualValue).to.eq(expectedValueRounded);
-        });
-      }
-    });
+            expect(actualValue).to.eq(expectedValueRounded);
+          });
+        }
+      },
+    );
   });
 
   context('Claim collateral from the liquidated vaults', () => {

--- a/test/e2e/specs/liquidation.spec.js
+++ b/test/e2e/specs/liquidation.spec.js
@@ -756,7 +756,7 @@ describe('Wallet App Test Cases', () => {
 
   context('Verification of Fully and Partially Filled Bids', () => {
     it("should see increase in the bidder's ATOM balance after liquidation", () => {
-      const expectedValue = 18.908;
+      const expectedValue = 18.91;
       cy.task(
         'info',
         `Expected increase due to completely filled bids: ${expectedValue}`,
@@ -770,7 +770,7 @@ describe('Wallet App Test Cases', () => {
         cy.task('info', `New Balance: ${newBalance}`);
 
         const balanceIncrease = Number(
-          (newBalance - bidderAtomBalance).toFixed(3),
+          (newBalance - bidderAtomBalance).toFixed(2),
         );
         cy.task('info', `Actual increase: ${balanceIncrease}`);
         bidderAtomBalance = Number(newBalance.toFixed(2));

--- a/test/e2e/specs/liquidation.spec.js
+++ b/test/e2e/specs/liquidation.spec.js
@@ -438,7 +438,9 @@ describe('Wallet App Test Cases', () => {
         field: 'shortfallBalance',
         latest: true,
       }).then(output => {
-        shortfallBalance = Number(Number(output.value.slice(1)).toFixed(2));
+        shortfallBalance = Number(
+          (Number(output.value.slice(1)) / 1_000_000).toFixed(2),
+        );
         cy.task('info', `Current Shortfall balance: ${shortfallBalance}`);
       });
     });

--- a/test/e2e/support.js
+++ b/test/e2e/support.js
@@ -15,7 +15,7 @@ const balanceUrl =
     : 'http://localhost:1317/cosmos/bank/v1beta1/balances/';
 const COMMAND_TIMEOUT = configMap[network].COMMAND_TIMEOUT;
 
-const agops = 'agops';
+const agops = '/usr/src/agoric-sdk/packages/agoric-cli/bin/agops';
 
 Cypress.Commands.add('addKeys', params => {
   const { keyName, mnemonic, expectedAddress } = params;
@@ -41,11 +41,9 @@ Cypress.Commands.add('setOraclePrice', price => {
       timeout: COMMAND_TIMEOUT,
     },
   ).then(({ stdout, stderr }) => {
-    if (stderr && !stdout) {
-      cy.task('error', `STDERR: ${stderr}`);
-      throw Error(stderr);
-    }
     cy.task('info', `STDOUT: ${stdout}`);
+    cy.task('info', `STDERR: ${stderr}`);
+
     expect(stdout).to.not.contain('Error');
     expect(stdout).to.not.contain('error');
   });

--- a/test/e2e/test.utils.js
+++ b/test/e2e/test.utils.js
@@ -13,7 +13,8 @@ export const accountAddresses = {
 
 export const webWalletURL = 'https://wallet.agoric.app/';
 export const MINUTE_MS = 1 * 60 * 1000;
-export const QUICK_WAIT = 10 * 1000;
+export const QUICK_WAIT_LOCAL = 10 * 1000;
+export const QUICK_WAIT_TESTNET = 20 * 1000;
 export const THIRTY_SECONDS = 30 * 1000;
 
 export const agoricNetworks = {


### PR DESCRIPTION
The PR does the following:
- Use absolute path for `agops` in CI. 
- Chores around bringing consistency in running e2e tests between a3p and testnets. 
- Wraps logs in a separate `then` callback. 
- Adds a retry mechanism for auction-specific test cases. 