### PR TITLE
update agoric synpress to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "zustand": "^4.1.5"
   },
   "devDependencies": {
-    "@agoric/synpress": "^3.8.3-beta.0",
+    "@agoric/synpress": "^3.8.3",
     "@cosmjs/encoding": "^0.32.2",
     "@keplr-wallet/types": "^0.12.55",
     "@leapwallet/elements": "^0.12.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -660,10 +660,10 @@
   resolved "https://registry.yarnpkg.com/@agoric/swingset-xsnap-supervisor/-/swingset-xsnap-supervisor-0.10.3-u14.0.tgz#14dd5c471544f6703940b4b7c77ec37cb8056f93"
   integrity sha512-vrZwHUphBxceQ7gTDoDIDHGcbXSm7gJpoabzmQQ++dRAktspjK7AccIZnMCBM52KZioJgRLsHwwSh/mXUdHZ7g==
 
-"@agoric/synpress@^3.8.3-beta.0":
-  version "3.8.3-beta.0"
-  resolved "https://registry.yarnpkg.com/@agoric/synpress/-/synpress-3.8.3-beta.0.tgz#75373a61726152ede76d8947579cbc2bddef1e72"
-  integrity sha512-G5bE6/m/rbSiubHysBbJVsJHtmkR7agN3UGAlRA5qObEoKMSGhpxYyT2iRH3erybSEq9MfCxgtOx2Lu8lTwqvA==
+"@agoric/synpress@^3.8.3":
+  version "3.8.3"
+  resolved "https://registry.yarnpkg.com/@agoric/synpress/-/synpress-3.8.3.tgz#17019f7a145aec65422def82a99ede18699d0909"
+  integrity sha512-610579GPDYKGfnVQWzhLamC6uOUoZtF2kdRSdjb1CjtWRpZKCX2IsCb19FrOtzbBQHWePyx7dBW3urHIA848JQ==
   dependencies:
     "@cypress/code-coverage" "^3.11.0"
     "@cypress/webpack-dev-server" "^3.5.2"


### PR DESCRIPTION
The `@agoric/synpress` version `3.8.3-beta.0` has been causing failures in both CI and local environments when running e2e tests with Chrome. Fortunately, our CI primarily utilizes the Chromium browser, which hasn’t been affected. 

Today, I encountered issues locally today while conducting liquidation tests to verify the indexing of liquidation data. To resolve this, I upgraded @agoric/synpress` to `3.8.3`, the latest version, which is compatible with Chrome and resolves these issues.