### PR TITLE
chore(deps): bump @agoric/rpc to v0.10.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@agoric/cosmic-proto": "^0.3.0",
     "@agoric/ertp": "^0.16.2",
     "@agoric/inter-protocol": "^0.16.1",
-    "@agoric/rpc": "^0.9.0",
+    "@agoric/rpc": "^0.10.0",
     "@agoric/smart-wallet": "^0.5.3",
     "@agoric/ui-components": "^0.9.0",
     "@agoric/wallet": "^0.18.3",
@@ -78,5 +78,6 @@
     "**/@agoric/xsnap": "0.14.3-u14.0",
     "**/@agoric/time": "0.3.3-u14.0",
     "**/@agoric/vats": "0.15.2-u15.0"
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -345,10 +345,10 @@
     "@endo/marshal" "0.8.5"
     "@endo/promise-kit" "0.2.56"
 
-"@agoric/rpc@^0.9.0":
-  version "0.9.0"
-  resolved "https://registry.yarnpkg.com/@agoric/rpc/-/rpc-0.9.0.tgz#bf43046fa855b666089797315af1085cb84d44a6"
-  integrity sha512-mJ7akVnEC/Gu0Gc/X0+NrVZ3/SC5QawcrWjyTkIBGZ+2geEmyPQ9euAEJ3Luq3cmcqi2XxF2NEHzU/0VU0SKng==
+"@agoric/rpc@^0.10.0":
+  version "0.10.0"
+  resolved "https://registry.yarnpkg.com/@agoric/rpc/-/rpc-0.10.0.tgz#bfbcf9712a1e130ecc9e55ba70734952c95eb6b7"
+  integrity sha512-A89Iaiu1bbSYGPq66wdPKL0IVqAM1kOiHsi8Wf+vN9+aSsrsRH3dOy8nWo/3dM/SAvM/GRBDZmLs6rPsizP6yw==
   dependencies:
     "@endo/marshal" "^0.8.9"
     axios "^1.6.2"


### PR DESCRIPTION
The PR upgrades `@agoric/rpc` from version `0.9.0` to `0.10.0` to fix issues with vstorage access with `xnet`.

## Context
Getting errors when trying to access data from storage. It is using incorrect paths such as:
```
/custom/vstorage/data/published.agoricNames.instance
```

All paths should begin with `/agoric/` instead of `/custom/`.