### PR TITLE
chore: update subquery url

### DIFF
--- a/src/utils/rpc.ts
+++ b/src/utils/rpc.ts
@@ -27,7 +27,7 @@ export const fetchAllAddrs = async (netconfigURL: string) => {
 
 export const queryTotalActiveVaults = async () => {
   const res = await fetch(
-    'https://api.subquery.network/sq/agoric-labs/agoric-mainnet-v2',
+    'https://index-api.onfinality.io/sq/agoric-labs/agoric-mainnet-v2',
     {
       method: 'POST',
       headers: {


### PR DESCRIPTION
Onfinality has changed the API URL. Right now both the old and new ones work so changing it pre-emptively on the inter dashboard. 

<img width="577" alt="image" src="https://github.com/user-attachments/assets/7c959df4-41b5-4e03-a1c5-d30abfffb6d5" />

Will be re-deploying the production indexer today so the old one will stop working as soon as its done.